### PR TITLE
CORE-4207 Fix static registration class name in exported group policy file

### DIFF
--- a/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicy.kt
+++ b/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicy.kt
@@ -66,7 +66,7 @@ class GenerateGroupPolicy(private val output: GroupPolicyOutput = ConsoleGroupPo
         val groupPolicy = mutableMapOf<String, Any>()
         groupPolicy["fileFormatVersion"] = 1
         groupPolicy["groupId"] = "ABC123"
-        groupPolicy["registrationProtocol"] = "net.corda.membership.staticnetwork.StaticMemberRegistrationService"
+        groupPolicy["registrationProtocol"] = "net.corda.membership.impl.registration.staticnetwork.StaticMemberRegistrationService"
         groupPolicy["synchronisationProtocolFactory"] = "net.corda.v5.mgm.MGMSynchronisationProtocolFactory"
         groupPolicy["protocolParameters"] = mutableMapOf(
             "identityTrustStore" to listOf(


### PR DESCRIPTION
Adjusting exported group policy file to use the correct static registration class name after refactoring the runtime os.