### PR TITLE
CORE-3206: Add network plugin

### DIFF
--- a/plugins/network/build.gradle
+++ b/plugins/network/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'org.jetbrains.kotlin.kapt'
+}
+
+dependencies {
+    compileOnly project(":api")
+
+    compileOnly "org.pf4j:pf4j:${pf4jVersion}"
+    kapt "org.pf4j:pf4j:${pf4jVersion}"
+
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junit5Version"
+    testImplementation "com.github.stefanbirkner:system-lambda:1.2.1"
+    testImplementation project(":api")
+    testImplementation "org.pf4j:pf4j:${pf4jVersion}"
+    testApi "info.picocli:picocli:${picoCliVersion}"
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/plugins/network/gradle.properties
+++ b/plugins/network/gradle.properties
@@ -4,4 +4,4 @@ jacksonVersion = 2.12.5
 pluginId=network
 pluginClass=net.corda.cli.plugins.network.NetworkPluginWrapper
 pluginProvider=R3
-pluginDescription="Plugin for deploying and managing a network."
+pluginDescription="Plugin for interacting with a network."

--- a/plugins/network/gradle.properties
+++ b/plugins/network/gradle.properties
@@ -1,0 +1,7 @@
+version=0.0.1
+
+jacksonVersion = 2.12.5
+pluginId=network
+pluginClass=net.corda.cli.plugins.network.NetworkPluginWrapper
+pluginProvider=R3
+pluginDescription="Plugin for deploying and managing a network."

--- a/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
+++ b/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
@@ -40,13 +40,13 @@ class NetworkPluginWrapper(wrapper: PluginWrapper) : Plugin(wrapper) {
         )
         fun getMembersList(
             @CommandLine.Option(
-                names = ["-v", "--vnode-id"],
+                names = ["-h", "--holding-identity-id"],
                 arity = "1",
-                description = ["Virtual node ID"]
-            ) virtualNodeId: String?
+                description = ["ID of the holding identity to be checked."]
+            ) holdingIdentityId: String?
         ) {
-            require(virtualNodeId != null)
-            service.get("/members?vnode-id=$virtualNodeId")
+            require(holdingIdentityId != null)
+            service.get("/members?holdingIdentityId=$holdingIdentityId")
         }
     }
 }

--- a/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
+++ b/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
@@ -1,0 +1,52 @@
+package net.corda.cli.plugins.network
+
+import net.corda.cli.api.CordaCliPlugin
+import net.corda.cli.api.serviceUsers.HttpServiceUser
+import net.corda.cli.api.services.HttpService
+import org.pf4j.Extension
+import org.pf4j.Plugin
+import org.pf4j.PluginWrapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import picocli.CommandLine
+import picocli.CommandLine.Mixin
+
+class NetworkPluginWrapper(wrapper: PluginWrapper) : Plugin(wrapper) {
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(NetworkPlugin::class.java)
+    }
+
+    override fun start() {
+        logger.debug("Network plugin started.")
+    }
+
+    override fun stop() {
+        logger.debug("Network plugin stopped.")
+    }
+
+    @Extension
+    @CommandLine.Command(
+        name = "network",
+        mixinStandardHelpOptions = true,
+        description = ["Plugin for deploying and managing a network."]
+    )
+    class NetworkPlugin : CordaCliPlugin, HttpServiceUser {
+        @Mixin
+        override lateinit var service: HttpService
+
+        @CommandLine.Command(
+            name = "members-list",
+            description = ["Shows the list of members on the network."]
+        )
+        fun getMembersList(
+            @CommandLine.Option(
+                names = ["-v", "--vnode-id"],
+                arity = "1",
+                description = ["Virtual node ID"]
+            ) virtualNodeId: String?
+        ) {
+            require(virtualNodeId != null)
+            service.get("/members?vnode-id=$virtualNodeId")
+        }
+    }
+}

--- a/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
+++ b/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
@@ -28,7 +28,7 @@ class NetworkPluginWrapper(wrapper: PluginWrapper) : Plugin(wrapper) {
     @CommandLine.Command(
         name = "network",
         mixinStandardHelpOptions = true,
-        description = ["Plugin for deploying and managing a network."]
+        description = ["Plugin for interacting with a network."]
     )
     class NetworkPlugin : CordaCliPlugin, HttpServiceUser {
         @Mixin

--- a/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
+++ b/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
@@ -19,7 +19,6 @@ class MembersListTest {
         tapSystemErrAndOutNormalized {
             CommandLine(app).execute("--user=test", "--password=test", "-t=$url", "members-list", "-v=$DUMMY_VNODE_ID")
         }.apply {
-            println(this)
             assertTrue(contains("$url/members?vnode-id=$DUMMY_VNODE_ID"))
         }
     }

--- a/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
+++ b/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
@@ -1,0 +1,26 @@
+package net.corda.cli.plugins.network
+
+import com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErrAndOutNormalized
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import picocli.CommandLine
+
+class MembersListTest {
+
+    companion object {
+        private const val DUMMY_VNODE_ID = "10"
+    }
+
+    @Test
+    fun `command correctly calls HTTP endpoint`() {
+        val app = NetworkPluginWrapper.NetworkPlugin()
+        app.service = MockHttpService()
+        val url = "https://test.r3.com"
+        tapSystemErrAndOutNormalized {
+            CommandLine(app).execute("--user=test", "--password=test", "-t=$url", "members-list", "-v=$DUMMY_VNODE_ID")
+        }.apply {
+            println(this)
+            assertTrue(contains("$url/members?vnode-id=$DUMMY_VNODE_ID"))
+        }
+    }
+}

--- a/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
+++ b/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MembersListTest.kt
@@ -8,7 +8,7 @@ import picocli.CommandLine
 class MembersListTest {
 
     companion object {
-        private const val DUMMY_VNODE_ID = "10"
+        private const val DUMMY_HOLDING_IDENTITY_ID = "10"
     }
 
     @Test
@@ -17,9 +17,15 @@ class MembersListTest {
         app.service = MockHttpService()
         val url = "https://test.r3.com"
         tapSystemErrAndOutNormalized {
-            CommandLine(app).execute("--user=test", "--password=test", "-t=$url", "members-list", "-v=$DUMMY_VNODE_ID")
+            CommandLine(app).execute(
+                "--user=test",
+                "--password=test",
+                "-t=$url",
+                "members-list",
+                "-h=$DUMMY_HOLDING_IDENTITY_ID"
+            )
         }.apply {
-            assertTrue(contains("$url/members?vnode-id=$DUMMY_VNODE_ID"))
+            assertTrue(contains("$url/members?holdingIdentityId=$DUMMY_HOLDING_IDENTITY_ID"))
         }
     }
 }

--- a/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MockHttpService.kt
+++ b/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MockHttpService.kt
@@ -1,0 +1,26 @@
+package net.corda.cli.plugins.network
+
+import net.corda.cli.api.services.HttpService
+import picocli.CommandLine
+
+class MockHttpService : HttpService {
+
+    @CommandLine.Option(names = ["-u", "--user"], description = ["User name"], required = true)
+    override var username: String? = null
+
+    @CommandLine.Option(names = ["-p", "--password"], description = ["Password"], required = true)
+    override var password: String? = null
+
+    @CommandLine.Option(names = ["-t", "--target-url"], description = ["The Swagger Url of the target."])
+    override var url: String? = null
+
+    override fun get(endpoint: String) { println("$url$endpoint") }
+
+    override fun put(endpoint: String, jsonBody: String) {}
+
+    override fun patch(endpoint: String, jsonBody: String) {}
+
+    override fun post(endpoint: String, jsonBody: String) {}
+
+    override fun delete(endpoint: String) {}
+}

--- a/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MockHttpService.kt
+++ b/plugins/network/src/test/kotlin/net/corda/cli/plugins/network/MockHttpService.kt
@@ -11,7 +11,7 @@ class MockHttpService : HttpService {
     @CommandLine.Option(names = ["-p", "--password"], description = ["Password"], required = true)
     override var password: String? = null
 
-    @CommandLine.Option(names = ["-t", "--target-url"], description = ["The Swagger Url of the target."])
+    @CommandLine.Option(names = ["-t", "--target-url"], description = ["Url of the target."])
     override var url: String? = null
 
     override fun get(endpoint: String) { println("$url$endpoint") }

--- a/settings.gradle
+++ b/settings.gradle
@@ -97,6 +97,7 @@ include 'api'
 include 'app'
 include 'plugins'
 include 'plugins:mgm'
+include 'plugins:network'
 include 'plugins:plugin1'
 include 'plugins:plugin2'
 


### PR DESCRIPTION
Jira: https://r3-cev.atlassian.net/browse/CORE-3206
Add `network` plugin and a subcommand `members-list` to view the member list via HTTP.
Tested with a mock server on Postman.

Sample command:
```
java -Dpf4j.pluginsDir=build/plugins -jar app/build/libs/corda-cli-0.0.1-beta.jar network --user=test --password=test -t=<base-url> members-list -h=<holdingIdentityId>
```