### PR TITLE
NOTICK: Fix parameters in quotes on Unix

### DIFF
--- a/script/corda-cli.sh
+++ b/script/corda-cli.sh
@@ -8,4 +8,4 @@ rootDir="$SCRIPTPATH/.."
 binDir="$rootDir/app/build/libs"
 pluginsDir="$rootDir/build/plugins"
 
-java  -Dpf4j.pluginsDir="$pluginsDir" -jar "$binDir/corda-cli-0.0.1-beta.jar" $@
+java  -Dpf4j.pluginsDir="$pluginsDir" -jar "$binDir/corda-cli-0.0.1-beta.jar" "$@"


### PR DESCRIPTION
When we run corda-cli.sh with parameters in quotes, we need it to preserve the quotes when running the java command. Currently they are removed by the parsing done to run the shell script itself.