### PR TITLE
NOTICK: Update jar filename in scripts

### DIFF
--- a/script/corda-cli-debug.cmd
+++ b/script/corda-cli-debug.cmd
@@ -11,4 +11,4 @@ for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 SET binDir="%APP_HOME%\app\build\libs"
 SET pluginsDir="%APP_HOME%\build\plugins"
 
-java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -Dpf4j.pluginsDir=%pluginsDir% -jar %binDir%\corda-cli-0.0.1-beta.jar %*
+java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -Dpf4j.pluginsDir=%pluginsDir% -jar %binDir%\corda-cli.jar %*

--- a/script/corda-cli.cmd
+++ b/script/corda-cli.cmd
@@ -11,4 +11,4 @@ for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 SET binDir="%APP_HOME%\app\build\libs"
 SET pluginsDir="%APP_HOME%\build\plugins"
 
-java -Dpf4j.pluginsDir=%pluginsDir% -jar %binDir%\corda-cli-0.0.1-beta.jar %*
+java -Dpf4j.pluginsDir=%pluginsDir% -jar %binDir%\corda-cli.jar %*

--- a/script/corda-cli.sh
+++ b/script/corda-cli.sh
@@ -8,4 +8,4 @@ rootDir="$SCRIPTPATH/.."
 binDir="$rootDir/app/build/libs"
 pluginsDir="$rootDir/build/plugins"
 
-java  -Dpf4j.pluginsDir="$pluginsDir" -jar "$binDir/corda-cli-0.0.1-beta.jar" "$@"
+java  -Dpf4j.pluginsDir="$pluginsDir" -jar "$binDir/corda-cli.jar" "$@"


### PR DESCRIPTION
The version number is no longer included in the jar filename when built. This change updates the scripts to use the new jar filename.