### PR TITLE
NOTICK: Ensure scripts use correct version of corda-cli.jar - generate these dynamically, also ensure corda-cli.jar is actually published 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ run `./gradlew build`
 
 As part of the build process scripts are generated in the 'build/generatedScripts' directory. This ensures scripts will always refer to the correct version of the corda-cli.jar. Running './gradlew build' will trigger copying of scripts from the root 'scripts' directory to 'build/generatedScripts' and update the version referenced in the scripts accordingly, along with generation of the needed Jars. You may also manually trigger this task with './gradlew generateVersionedScripts' if required, but the corda-cli jar must be generated and present in the 'app\build\libs' to execute these scripts.
 
-In the build/generatedScripts directory there is a windows cmd shell command script that can be called after a gradlew
-Build. `corda-cli.cmd` etc
+In the build/generatedScripts directory there is a windows cmd and shell command script that can be called after a gradlew Build. `corda-cli.cmd` etc
 
 ## The Plugins
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ run `./gradlew build`
 
 ## Running The CLI Script
 
-In the script directory there is a windows cmd shell command script that can be called after a gradlew
+As part of the build process scripts are generated in the 'build/generatedScripts' directory. This ensures scripts will always refer to the correct version of the corda-cli.jar. Running './gradlew build' will trigger copying of scripts from the root 'scripts' directory to 'build/generatedScripts' and update the version referenced in the scripts accordingly, along with generation of the needed Jars. You may also manually trigger this task with './gradlew generateVersionedScripts' if required, but the corda-cli jar must be generated and present in the 'app\build\libs' to execute these scripts.
+
+In the build/generatedScripts directory there is a windows cmd shell command script that can be called after a gradlew
 Build. `corda-cli.cmd` etc
 
 ## The Plugins

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ test {
 }
 
 def appMainClass = "net.corda.cli.application.BootKt"
+def vcsUrl = System.getenv('GIT_URL') ?: 'https://github.com/corda/corda-cli-plugin-host.git'
 
 application {
     mainClass = appMainClass
@@ -84,4 +85,41 @@ tasks.named("publishOSGiImage").configure{
 
 artifacts {
     archives fatJar
+}
+
+// required as fatJar artifact not handled by r3Publish
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact fatJar
+            artifactId = "corda-cli"
+            version  = project.version
+
+            pom {
+                name = 'corda-cli'
+                url = vcsUrl - '.git'
+                scm {
+                    url = vcsUrl
+                }
+                
+                if ((project.hasProperty("licenseName")) && (project.hasProperty("licenseUrl"))) {
+                    licenses {
+                        license {
+                            name = licenseName
+                            url = licenseUrl
+                            distribution = licenseUrl
+                        }
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'R3'
+                        name = 'R3'
+                        email = 'dev@corda.net'
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,36 +90,44 @@ artifacts {
 // required as fatJar artifact not handled by r3Publish
 publishing {
     publications {
-        maven(MavenPublication) {
-            artifact fatJar
-            artifactId = "corda-cli"
-            version  = project.version
+            configureEach {
+                pom {
+                    name = 'corda-cli'
+                    url = vcsUrl - '.git'
+                    scm {
+                        url = vcsUrl
+                    }
+                    
+                    if ((project.hasProperty("licenseName")) && (project.hasProperty("licenseUrl"))) {
+                        licenses {
+                            license {
+                                name = licenseName
+                                url = licenseUrl
+                                distribution = licenseUrl
+                            }
+                        }
+                    }
 
-            pom {
-                name = 'corda-cli'
-                url = vcsUrl - '.git'
-                scm {
-                    url = vcsUrl
-                }
-                
-                if ((project.hasProperty("licenseName")) && (project.hasProperty("licenseUrl"))) {
-                    licenses {
-                        license {
-                            name = licenseName
-                            url = licenseUrl
-                            distribution = licenseUrl
+                    developers {
+                        developer {
+                            id = 'R3'
+                            name = 'R3'
+                            email = 'dev@corda.net'
                         }
                     }
                 }
-
-                developers {
-                    developer {
-                        id = 'R3'
-                        name = 'R3'
-                        email = 'dev@corda.net'
-                    }
-                }
             }
-        }
+
+            mavenFatJar(MavenPublication) {
+                artifact fatJar
+                artifactId = "corda-cli"
+                version  = project.version
+            }
+
+            mavenAppJar(MavenPublication) {
+                artifact jar
+                artifactId = "app"
+                version  = project.version
+            }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ def fatJar = tasks.register('fatJar', Jar) {
     }
 
     archiveBaseName = 'corda-cli'
+    archiveVersion = project.version
 }
 
 tasks.named("publishOSGiImage").configure{

--- a/build.gradle
+++ b/build.gradle
@@ -115,4 +115,4 @@ tasks.register("copyScripts", Copy){
 }
 
 // Automatically ran as part of build process
-build.finalizedBy(generateVersionedScripts)
+assemble.finalizedBy(generateVersionedScripts)

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ subprojects {
 wrapper {
     gradleVersion = '7.3.2'
     distributionType = Wrapper.DistributionType.BIN
-    distributionUrl="https://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-$gradleVersion-bin.zip"
 }
 
 tasks.register("generateVersionedScripts"){

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'com.r3.internal.gradle.plugins.r3-docker' apply false
 }
 
+  
 ext.pluginsDir = "$buildDir/plugins"
 
 if (System.getenv("RELEASE_VERSION")?.trim()) {

--- a/build.gradle
+++ b/build.gradle
@@ -13,28 +13,31 @@ plugins {
 
 ext.pluginsDir = "$buildDir/plugins"
 
+if (System.getenv("RELEASE_VERSION")?.trim()) {
+    version = System.getenv("RELEASE_VERSION")
+} else {
+    def versionSuffix = '-SNAPSHOT'
+    if (System.getenv('VERSION_SUFFIX')) {
+        versionSuffix = System.getenv('VERSION_SUFFIX')
+    }
+    version = "$cliHostVersion$versionSuffix"
+}
+
 subprojects {
 
-    if (System.getenv("RELEASE_VERSION")?.trim()) {
-        version = System.getenv("RELEASE_VERSION")
-    } else {
-        def versionSuffix = '-SNAPSHOT'
-        if (System.getenv('VERSION_SUFFIX')) {
-            versionSuffix = System.getenv('VERSION_SUFFIX')
-        }
-        version = "$cliHostVersion$versionSuffix"
-    }
     group = 'net.corda.cli'
+    version rootProject.version
 
 
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm'){
         apply plugin: 'io.gitlab.arturbosch.detekt'
 
-
         dependencies {
             detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
         }
     }
+
+
 
     tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {
@@ -87,3 +90,28 @@ wrapper {
     distributionType = Wrapper.DistributionType.BIN
     distributionUrl="https://gradleproxy:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-$gradleVersion-bin.zip"
 }
+
+tasks.register("generateVersionedScripts"){
+    description 'Wrapper task to ensure we have the correct version specified in provided scripts'
+    dependsOn cleanDir, copyScripts
+}
+
+
+tasks.register("cleanDir", Delete){
+    description 'Removes any previously generated scripts'
+    delete 'build/generatedScripts' 
+}
+
+tasks.register("copyScripts", Copy){
+    mustRunAfter cleanDir
+    description 'Copy corda-cli scripts to a location in build dir and update to use correct version'
+
+    from 'script' 
+    into 'build/generatedScripts' 
+    filter {
+            String line -> line.replaceAll("corda-cli-.(.)*.jar", "corda-cli-${version}.jar")
+        }
+}
+
+// Automatically ran as part of build process
+build.finalizedBy(generateVersionedScripts)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://gradleproxy\:gradleproxy@software.r3.com/artifactory/gradle-proxy/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Currently Scripts in /scripts reference a static version of the corda-cli example:

`java -Dpf4j.pluginsDir=%pluginsDir% -jar %binDir%\corda-cli-0.0.1-beta.jar %*`

- To prevent either having to remove the version or constantly update it. I have updated build process to copy scripts from 'scripts' directory to 'build/generatedScripts' and append the correct version number to the invoking scripts. A user can then use these rather than the scripts in 'scripts'. These will be generated once the './gradlew build' command runs but can also be optionally triggered independently with './gradlew generateVersionedScripts'

- addressed issues where version number was not been correctly set on sub projects and Jars were being published with version 'unspecified'. 

- ensure corda-cli.jar as generated by fat jar task is being published by CI, prior to this PR this was not happening, publishing block added to 'app' submodule handles this 

- standardizing how we use Gradle distributionUrl in line with other C5 projects

- updated readme.md with relevant info.