### PR TITLE
CORE-4749 Investigate cleaning up Detect output when building runtimeos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,21 +67,20 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'maven-publish'
 
-    detekt {
+    tasks.named("detekt").configure {
+        if(file("$projectDir/detekt-baseline.xml").exists()){
+            baseline = file("$projectDir/detekt-baseline.xml")
+        }
+        ignoreFailures = true
         config.setFrom(files("$rootDir/detekt-config.yml"))
         parallel = true
-        ignoreFailures = true
         reports {
-            xml {
-                enabled = true
-                destination = file("$projectDir/build/detekt-report.xml")
+            xml{
+                outputLocation.set(file("$projectDir/build/detekt-report.xml"))
             }
-            html {
-                enabled = false
-            }
-            txt {
-                enabled = false
-            }
+            txt.required.set(false)
+            sarif.required.set(false)
+            html.required.set(false)
         }
     }
 }


### PR DESCRIPTION
Re-work to the configuration of the detekt task as the neccessary xml reports were not being generated & there was excessive logging of the following error message:
'XML report location set on detekt {} extension will be ignored for detekt task. See https://detekt.github.io/detekt/gradle.html#reports '.
The check for the baseline xml file to try to combat the eager task realization for evaluating projects without the needed baseline xml file.
Verified locally - xml reports generated and logging noise removed.