### PR TITLE
CORE-4807 remove ability to have NOTICK tickets from all open sourced branches

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,14 @@
+name: 'PR title check'
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.4.2
+        with:
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+)(.*)'
+          on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
going forward this will check to ensure you have a valid Jira reference when committing work on this repo - NOTICK will not suffice