### PR TITLE
CORE-4724: generate information from Nexus

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,5 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
-
 cordaNexusScanPipeline(
-    nexusAppId: 'net.corda-cli-host-5.0'
+    nexusAppId: 'net.corda-cli-host-5.0',
+    nexusAppStage: 'build'
 )


### PR DESCRIPTION
* start using newly introduced functionality of `cordaNexusScanPipeline`
  and define Nexus stage to create reports for
* reports are collected as artifacts:
    * `report/ossreport-net.corda-api-5.0.md`
    * `wiki-report.md`

A test build is at https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNexus-Scan-Corda-CLI-Plugin-Host/detail/CORE-4724-Generate-License-report-and-wiki-report-for-all-C5-open-source-projects-to-be-archived-as-part-of-dedicate-nexus-job/6/artifacts