### PR TITLE
CORE-4724: Revert generate information from Nexus

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,5 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
+
 cordaNexusScanPipeline(
-    nexusAppId: 'net.corda-cli-host-5.0',
-    nexusAppStage: 'build'
+    nexusAppId: 'net.corda-cli-host-5.0'
 )


### PR DESCRIPTION
This reverts commit 6cdc65a8be7a70270ba6fbc5983f136a30954c30. (#40)

It is no longer needed as a newly introduced parameter has been removed.

Test build at https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNexus-Scan-Corda-CLI-Plugin-Host/detail/CORE-4724-fixes/1/artifacts