### PR TITLE
CORE-4643: add contributors list as place holder for open sourcing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,15 +1,24 @@
-Alexey Kadyrov (R3)
-Ben McMahon (R3)
-Charlie Crean (R3)
-Chris Barratt (R3)
-Chris Rankin (R3)
-Christian Sailer (R3)
-Connel McGovern (R3)
-Dimos Raptis (R3)
-HJ Kim (R3)
-Joseph Zuniga-Daly (R3)
-Nikolett Nagy (R3)
-Peter McKinney (R3)
-Ronan Browne (R3)
-Waldemar Żurowski (R3)
-Yash Nabar (R3)
+# List of Contributors
+
+We'd like to thank the following people for contributing to Corda, either by
+contributing to the design of Corda during the architecture review sessions of the
+R3 Architecture Working Group and during design reviews since Corda has been
+open-sourced, or by contributing code via pull requests. Some people have
+moved to a different organisation since their contribution. Please forgive any
+omissions, and create a pull request if you wish to see changes to this list.
+
+* Alexey Kadyrov (R3)
+* Ben McMahon (R3)
+* Charlie Crean (R3)
+* Chris Barratt (R3)
+* Chris Rankin (R3)
+* Christian Sailer (R3)
+* Connel McGovern (R3)
+* Dimos Raptis (R3)
+* HJ Kim (R3)
+* Joseph Zuniga-Daly (R3)
+* Nikolett Nagy (R3)
+* Peter McKinney (R3)
+* Ronan Browne (R3)
+* Waldemar Żurowski (R3)
+* Yash Nabar (R3)


### PR DESCRIPTION
generated with `git shortlog -s -n --all` and then some formatting