### PR TITLE
NOTICK - Switch gonepostal infix to p2p-preview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.stdlib.default.dependency=false
 
 # The version of cli-host we will publish
-cliHostVersion= 0.0.1-gonepostal
+cliHostVersion= 0.0.1-p2p-preview
 
 # PF4J
 pf4jVersion=3.6.0


### PR DESCRIPTION
Switching from `gonepostal` to `p2p-preview` to prevent confusion.