### PR TITLE
CORE-4923 Added a workflow folder and the pr-list test set on version 1.6.1

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,14 @@
+name: 'PR title check'
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: morrisoncole/pr-lint-action@v1.6.1
+        with:
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+|NOTICK)(.*)'
+          on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Ensures a Jira ticket is present - still allows notick 