### PR TITLE
CORE-5333: add build cache for local and CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ artifactoryPluginVersion = 4.28.2
 gradleEnterpriseVersion = 3.8.1
 gradleDataPlugin = 1.6.2
 gradleTestRetryPluginVersion = 1.3.1
-org.gradle.caching = false
+org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 
 #snyk version

--- a/settings.gradle
+++ b/settings.gradle
@@ -128,5 +128,26 @@ gradleEnterprise {
             accessKey = apiKey
         }
     }
+    buildCache {
+        local {
+            enabled = true
+            removeUnusedEntriesAfterDays = 14  // Garbage collect if a cache item is not used in 2 weeks.
+        }
+        remote(HttpBuildCache) {
+            url = "${gradleEnterpriseUrl}/cache/"
+            credentials {
+                username = settings.ext.find('BUILD_CACHE_CREDENTIALS_USR') ?: System.getenv('BUILD_CACHE_CREDENTIALS_USR')
+                password = settings.ext.find('BUILD_CACHE_CREDENTIALS_PSW') ?: System.getenv('BUILD_CACHE_CREDENTIALS_PSW')
+            }
+            // For the remote build cache we will populate cache only from Jenkins, all machines can pull from cache however.
+            if (System.getenv().containsKey("JENKINS_URL")) {
+                push = true
+                enabled = true
+            } else {
+                push = false
+                enabled = false
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
- set up cache for remote and local builds
- set local cache garbage collection to 2 weeks
- Note: cache location is in $GRADLE_USER_HOME/caches
- can be disabled via command line if required by adding --no-build-cache or changing the property org.gradle.caching in gradle.properties to false

No action is needed by end user, gradle will use the cached outputs of a task if appropriate. 