### PR TITLE
CORE-6161: add dependency checker to cli host

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'jacoco' // test coverage
     id 'corda.root-publish'
     id 'io.snyk.gradle.plugin.snykplugin'
+    id 'com.github.ben-manes.versions' // discover possible dependency version upgrades
 }
 
 snyk {
@@ -114,6 +115,17 @@ tasks.register("copyScripts", Copy){
     filter {
             String line -> line.replaceAll("corda-cli-.(.)*.jar", "corda-cli-${version}.jar")
         }
+}
+
+def isNonStable = { String version ->
+    def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+    def regex = /^[0-9,.v-]+(-r)?$/
+    return !stableKeyword && !(version ==~ regex)
+}
+tasks.named("dependencyUpdates").configure {
+    rejectVersionIf {
+        isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+    }
 }
 
 // Automatically ran as part of build process

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,7 @@ junitBomVersion=5.8.2
 detektPluginVersion = 1.21.+
 internalPublishVersion=1.+
 jibCoreVersion=0.16.0
+dependencyCheckVersion=0.42.0
 
 # Artifactory
 artifactoryContextUrl = https://software.r3.com/artifactory

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,7 @@ pluginManagement {
         id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPlugin
         id "com.jfrog.artifactory" version artifactoryPluginVersion
         id 'io.snyk.gradle.plugin.snykplugin' version snykVersion
+        id 'com.github.ben-manes.versions' version dependencyCheckVersion
     }
 }
 


### PR DESCRIPTION
Add support to corda-cli-host to leverage [gradle-versions-plugin: Gradle plugin to discover dependency updates](https://github.com/ben-manes/gradle-versions-plugin)  to check for latest plugins / dependencies.


This allows us to run a scan via gradle task (./gradlew dependencyUpdates) and access when a newer version of given dependency is available. This is then integrated into automation which checks for latest versions.

Logic already exists in api / runtime-os.