### PR TITLE
CORE-6535: work when corda-cli.sh run via a symlink

### DIFF
--- a/templateScripts/corda-cli.sh
+++ b/templateScripts/corda-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # get path to script
-SCRIPTPATH=$(dirname "$0")
+SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
 
 rootDir="$SCRIPTPATH/../.."
 binDir="$rootDir/app/build/libs"


### PR DESCRIPTION
Before this change, corda-cli.sh has to be run from the repository, since it uses relative paths to find plugins. If you want corda-cli on your path, you might choose to create a symbolic link somewhere on your path such as /usr/local/bin to the script. This doesn't work, since the symlink is not resolved, so the plugins would have to be copied to a subdirectory relative to the symlink, e.g. underneath /usr/local/bin. With this change, if corda-cli.sh is executed via a symlink, that symlink is resolved, and if corda-cli.sh is run directly there's no change.


See https://stackoverflow.com/questions/3373132/get-the-name-of-the-directory-where-a-script-is-executed for an explanation of the shell mechanism used.