### PR TITLE
CORE-6594: Add nexus scanning for corda-cli-plugin-host

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,5 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaNexusScanPipeline(
-    nexusAppId: 'net.corda-cli-host-5.0'
+    nexusAppId: 'net.corda-cli-host-0.0.1'
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,6 @@ cordaPipeline(
     runIntegrationTests: false,
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',
-    publishRepoPrefix: 'engineering-tools-maven'
+    publishRepoPrefix: 'engineering-tools-maven',
+    nexusAppId: 'net.corda-cli-host-0.0.1'
 )


### PR DESCRIPTION
* Added nexus id net.corda-cli-host-0.0.1 to pipeline to include Nexus scanning for all builds