### PR TITLE
CORE-6607: Fix C5 Composite build - Issue for QA (M1) running composite build locally

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ def fatJar = tasks.register('fatJar', Jar) {
     dependsOn(tasks.named('jar', Jar))
 
     from(sourceSets.main.output)
-    from(configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }) {
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"


### PR DESCRIPTION
Minor modification to fatJar task syntax as the runtime classpath was not being evaluated properly on the composite build for Corda 5 projects (Included builds: corda-runtime-os, corda-api, corda-cli-host-plugin)

Error:
```
  FAILURE: Build failed with an exception.
  
  * Where:
  Build file '/var/jenkins/workspace/Corda5/Open-Sourcing/Release_Branch/Corda_Composite_Build/corda-cli-plugin-host/app/build.gradle' line: 61
  
  * What went wrong:
  Could not determine the dependencies of task ':tools:plugins:publishOSGiImage'.
  > Could not create task ':corda-cli-plugin-host:app:publishOSGiImage'.
     > Could not create task ':corda-cli-plugin-host:app:fatJar'.
        > Could not resolve all dependencies for configuration ':corda-cli-plugin-host:app:runtimeClasspath'.
           > Project#beforeEvaluate(Action) on project ':corda-api' cannot be executed in the current context.
```

As per the documentation [here](https://docs.gradle.org/current/userguide/working_with_files.html#sec:creating_uber_jar_example) wrapping the copy from in braces