### PR TITLE
CORE-6671: Undo call to `readlink`

### DIFF
--- a/templateScripts/corda-cli.sh
+++ b/templateScripts/corda-cli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # get path to script
-SCRIPTPATH="$(dirname "$(readlink -f "$0")")"
+SCRIPTPATH=$(dirname "$0")
 
 rootDir="$SCRIPTPATH/../.."
 binDir="$rootDir/app/build/libs"


### PR DESCRIPTION
As option `readlink -f` does not work on MacOS.

This in effect reverts: https://github.com/corda/corda-cli-plugin-host/pull/77