### PR TITLE
CORE-6376: ensure cli-host project can push to s3 for tag builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@ cordaPipeline(
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',
     publishRepoPrefix: 'engineering-tools-maven',
-    nexusAppId: 'net.corda-cli-host-0.0.1'
+    nexusAppId: 'net.corda-cli-host-0.0.1',
+    publishToMavenS3Repository: true
 )


### PR DESCRIPTION
logic picked up by Jenkins shared lib which allows a push event to QA staging area on a tag build