### PR TITLE
CORE-6739: update corda cli to only produce one jar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,9 +60,9 @@ tasks.named("run") {
     }
 }
 
-def fatJar = tasks.register('fatJar', Jar) {
+def fatJar = tasks.named('jar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    dependsOn(tasks.named('jar', Jar))
+    //dependsOn(tasks.named('jar', Jar))
 
     from(sourceSets.main.output)
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
@@ -149,11 +149,11 @@ publishing {
             version = project.version
         }
 
-        mavenAppJar(MavenPublication) {
-            artifact jar
-            artifactId = "app"
-            version = project.version
-        }
+        // mavenAppJar(MavenPublication) {
+        //     artifact jar
+        //     artifactId = "app"
+        //     version = project.version
+        // }
     }
     
     if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ publishing {
 
         mavenCordaCLi(MavenPublication) {
             artifact cordaCLi
-            artifactId = "app"
+            artifactId = "corda-cli"
             version = project.version
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,11 +60,10 @@ tasks.named("run") {
     }
 }
 
-def fatJar = tasks.named('jar', Jar) {
+def cordaCLi = tasks.named('jar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    //dependsOn(tasks.named('jar', Jar))
 
-    from(sourceSets.main.output)
+    from (sourceSets.main.output)
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
@@ -85,8 +84,8 @@ def fatJar = tasks.named('jar', Jar) {
 }
 
 tasks.register('publishOSGiImage', DeployableContainerBuilder) {
-    sourceTasks = Arrays.asList(fatJar.get())
-    dependsOn(fatJar)
+    sourceTasks = Arrays.asList(cordaCLi.get())
+    dependsOn(cordaCLi)
     overrideEntryName = 'cli'
     overrideContainerName = 'cli'
     arguments = Arrays.asList("-Dpf4j.pluginsDir=/opt/override/plugins")
@@ -109,10 +108,10 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
 }
 
 artifacts {
-    archives fatJar
+    archives cordaCLi
 }
 
-// required as fatJar artifact not handled by r3Publish
+// required as cordaCLi artifact not handled by r3Publish
 publishing {
     publications {
         configureEach {
@@ -143,17 +142,11 @@ publishing {
             }
         }
 
-        mavenFatJar(MavenPublication) {
-            artifact fatJar
-            artifactId = "corda-cli"
+        mavenCordaCLi(MavenPublication) {
+            artifact cordaCLi
+            artifactId = "app"
             version = project.version
         }
-
-        // mavenAppJar(MavenPublication) {
-        //     artifact jar
-        //     artifactId = "app"
-        //     version = project.version
-        // }
     }
     
     if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {


### PR DESCRIPTION
- rather than publishing a default jar and a fat jar, just publish one jar, leverage the Jar task rather than registering a new fatJar task

Needs to resolve composite build issue as corda-runtime-os, where we cant resolve the cli dependency.
 
A composite build doesn't handle non standard ‘extra’ artifacts well, in this case having 2 artifacts in corda-cli-plugin-host:app is the root of the issue, we only need one artifact here, we can refactor the standard Jar task to contain everything we need 


accompanying fix https://github.com/corda/corda-runtime-os/pull/2121 