### PR TITLE
NOTICK: Configure project to use Java 11 toolchain.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import static org.gradle.api.JavaVersion.VERSION_11
+import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'org.jetbrains.kotlin.jvm' apply false
@@ -36,9 +37,14 @@ subprojects {
     group = 'net.corda.cli'
     version rootProject.version
 
-
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm'){
         apply plugin: 'io.gitlab.arturbosch.detekt'
+
+        kotlin {
+            jvmToolchain {
+                languageVersion = of(11)
+            }
+        }
 
         dependencies {
             detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,13 @@ cliHostVersion=0.0.1
 # PF4J
 pf4jVersion=3.7.0
 
-kotlinVersion=1.7.0
+kotlinVersion=1.7.10
 
 kafkaClientVersion=2.8.1_1
 
 # Logging
-log4jVersion=2.17.0
-slf4jVersion=1.7.32
+log4jVersion=2.17.2
+slf4jVersion=1.7.36
 
 # pico CLI
 picoCliVersion=4.6.3


### PR DESCRIPTION
Configure build to use Java 11 toolchain rather than relying on whichever JVM Gradle is using.

Also update dependencies:
- Kotlin 1.7.0 -> 1.7.10
- SLF4J 1.7.32 -> 1.7.36
- Log4J 2.17.0 -> 2.17.2