### PR TITLE
CORE-6681: ensure snake yaml uses 1.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         }
     }
 
-    // required untill detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
+    // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
     pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
         dependencies {
             detekt "org.yaml:snakeyaml:$snakeyamlVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ subprojects {
         }
     }
 
+    // required untill detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
+        dependencies {
+            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
+        }
+    }
+
     tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {
             languageVersion = '1.7'

--- a/build.gradle
+++ b/build.gradle
@@ -45,16 +45,16 @@ subprojects {
         }
     }
 
-     pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
-         dependencies {
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
+        dependencies {
             detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
-                constraints {
-                    detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
-                        because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
-                    }
+            constraints {
+                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                    because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
                 }
-         }
-     }
+            }
+        }
+    }
 
     tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,16 @@ subprojects {
         }
     }
 
-    // required untill detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
-    pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
-        dependencies {
-            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
-        }
-    }
+     pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
+         dependencies {
+            detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
+                constraints {
+                    detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                        because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
+                    }
+                }
+         }
+     }
 
     tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {


### PR DESCRIPTION
io.gitlab.arturbosch.detekt pulls in a transitive dependency on snake yaml 1.31 , until Deteck bump their version in a later release we need to force gradle to use the same version of snake yaml decaled in our gradle.properties file (1.32)