### PR TITLE
CORE-6549: clean redundant code releasable property not required on this module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'corda.common-publishing'
 }
 
-ext {
-    releasable = true
-}
-
 dependencies {
     implementation project(":api")
 


### PR DESCRIPTION
remove `releasable ` property from the app module as this module is not needed to be externally available for DP2, it only needs to be transitively available to the corda-runtime-os Build process to produce the CLI distribution (which it already is)