### PR TITLE
CORE-5480: test multi arch support

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -206,6 +206,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
         if (System.getenv().containsKey("JENKINS_URL")) {
+            logger.quiet("*** SET ARCH *** ")  //temp
             Set<Platform> platformSet = new HashSet<Platform>()
             platformSet.add(new Platform("arm64", "linux"))
             platformSet.add(new Platform("amd64", "linux"))

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -217,6 +217,11 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             platformSet.add(new Platform("arm64", "linux"))
             builder.setPlatforms(platformSet)
             tagPrefix = "arm64-"
+        } else {
+            logger.quiet("Detected amd64 host, switching Jib to produce amd64 images")
+            Set<Platform> platformSet = new HashSet<Platform>()
+            platformSet.add(new Platform("amd64", "linux"))
+            builder.setPlatforms(platformSet)        
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -285,10 +285,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         if (remotePublish.get()) {
             builder.containerize(
                     Containerizer.to(RegistryImage.named("${targetRepo}:${tag}")
-                            .addCredential(registryUsername.get(), registryPassword.get())).setAlwaysCacheBaseImage(true))
+                            .addCredential(registryUsername.get(), registryPassword.get())).setAlwaysCacheBaseImage(true).setEnablePlatformTags(true))
         } else {
             builder.containerize(
-                    Containerizer.to(DockerDaemonImage.named("${targetRepo}:${tag}")).setAlwaysCacheBaseImage(true)
+                    Containerizer.to(DockerDaemonImage.named("${targetRepo}:${tag}")).setAlwaysCacheBaseImage(true).setEnablePlatformTags(true)
             )
         }
 

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -205,12 +205,11 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
-        if (System.properties['os.arch'] == "aarch64") {
-            logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
+        if (System.getenv().containsKey("JENKINS_URL")) {
             Set<Platform> platformSet = new HashSet<Platform>()
             platformSet.add(new Platform("arm64", "linux"))
+            platformSet.add(new Platform("amd64", "linux"))
             builder.setPlatforms(platformSet)
-            tagPrefix = "arm64-"
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -285,10 +285,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         if (remotePublish.get()) {
             builder.containerize(
                     Containerizer.to(RegistryImage.named("${targetRepo}:${tag}")
-                            .addCredential(registryUsername.get(), registryPassword.get())).setAlwaysCacheBaseImage(true).setEnablePlatformTags(true))
+                            .addCredential(registryUsername.get(), registryPassword.get())).setAlwaysCacheBaseImage(true))
         } else {
             builder.containerize(
-                    Containerizer.to(DockerDaemonImage.named("${targetRepo}:${tag}")).setAlwaysCacheBaseImage(true).setEnablePlatformTags(true)
+                    Containerizer.to(DockerDaemonImage.named("${targetRepo}:${tag}")).setAlwaysCacheBaseImage(true)
             )
         }
 

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -206,11 +206,17 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
         if (System.getenv().containsKey("JENKINS_URL")) {
-            logger.quiet("*** SET ARCH *** ")  //temp
+            logger.quiet("Running on CI server - producing arm64 and amd64 images")
             Set<Platform> platformSet = new HashSet<Platform>()
             platformSet.add(new Platform("arm64", "linux"))
             platformSet.add(new Platform("amd64", "linux"))
             builder.setPlatforms(platformSet)
+        } else if (System.properties['os.arch'] == "aarch64") { 
+            logger.quiet("Detected arm64 host, switching Jib to produce arm64 images")
+            Set<Platform> platformSet = new HashSet<Platform>()
+            platformSet.add(new Platform("arm64", "linux"))
+            builder.setPlatforms(platformSet)
+            tagPrefix = "arm64-"
         }
 
         def containerName = overrideContainerName.get().empty ? projectName : overrideContainerName.get()

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ junitBomVersion=5.8.2
 
 detektPluginVersion = 1.21.+
 internalPublishVersion=1.+
-jibCoreVersion=0.16.0
+jibCoreVersion=0.22.0
 dependencyCheckVersion=0.42.0
 
 # Artifactory


### PR DESCRIPTION
Allow our CIs to produce multi arch compatible images and remove the need for a dedicated ARM job.

- Jenkins will produce 1 image, but it's manifest file will have 2 different architecture types. Local users with ARM machines (M1s etc) may still build from source if they wish.

sample output of `docker manifest inspect corda-os-docker-dev.software.r3.com/corda-os-cli:5.0.0-alpha-1665397095553` -Image produced by this PR

```

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 760,
         "digest": "sha256:fcc2e9e17e2d53de10228226844eb0dea3170dbccfa69a17a75dc26c0954aa42",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 760,
         "digest": "sha256:ed033f84ceb7927549e55f293286be6139f0d773877b35bcf42dd6c38763078b",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

Here we see both Arch types supported. and results in a `list.manifest.json` being published to Artifactory with this information 


