### PR TITLE
CORE-6930: Eliminate Log4j2 reconfiguration error

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -184,7 +184,6 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
         List<String> javaArgs = new ArrayList<String>(arguments.get())
         javaArgs.add("-Dlog4j2.debug=\${ENABLE_LOG4J2_DEBUG:-false}")
-        javaArgs.add("-Dlog4j.configurationFile=\${LOG4J_CONFIG_FILE}")
 
         if (setEntry.get()) {
             def entryName = overrideEntryName.get().empty ? projectName : overrideEntryName.get()
@@ -201,7 +200,6 @@ abstract class DeployableContainerBuilder extends DefaultTask {
                 builder.addEnvironmentVariable(key, value)
             }
         }
-        builder.addEnvironmentVariable('LOG4J_CONFIG_FILE', 'log4j2-console.xml')
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 


### PR DESCRIPTION
Since we were passing an invalid file `log4j2-console.xml` as Log4J2 configuration, the error mentioned on the Jira was occurring.

These lines were removed, since a special `log4j2.xml` file is packaged inside CLI Plugin Host Jar, and such login configuration should never need to be changed.

I have tested the effect of this change locally by using `gradlew -PcompositeBuild=true :tools:plugins:publishOSGiImage` from `corda-runtime-os` repo.