### PR TITLE
NOTICK: ensure we use a multi-arch supported base image

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -89,7 +89,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('11')
+            getObjects().property(String).convention('11.0.15-11.56.19')
 
     @Input
     final Property<String> subDir =


### PR DESCRIPTION
- update to resolve issue where azul/zulu-openjdk:11 tag was not evaluating to a image which supported multi arch builds, this broke docker image building as JIB now expects a base image which supports this, updating to `11.0.15-11.56.19` which specifically supports this 


output of  `docker manifest inspect azul/zulu-openjdk:11.0.15-11.56.19`  we see both arch types listed (unlike if same commands ran on 11)


  ```
{
     "schemaVersion": 2,
     "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
     "manifests": [
        {
           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
           "size": 742,
           "digest": "sha256:aa8b2313b12ac8a4dba5de01b691784f7662c134b10cc26a8e988f577f9f04fe",
           "platform": {
              "architecture": "arm64",
              "os": "linux",
              "variant": "v8"
           }
        },
        {
           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
           "size": 742,
           "digest": "sha256:b0647a18bf46b0f4f31b50565fe280f7d788bab43c44fe3f050ccbde47afc45f",
           "platform": {
              "architecture": "amd64",
              "os": "linux"
           }
        }
     ]
  }
```