### PR TITLE
NOTICK: add ability to override multi arch support in image publishing 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,9 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     environment = Map.of(
             "CORDA_CLI_HOME_DIR", "/opt/override/home"
     )
+    if (project.hasProperty('multiArchSupport')) {
+        multiArch = multiArchSupport.toBoolean()
+    }
     setEntry = true
 }
 


### PR DESCRIPTION
No change to existing default behavior of image publishing but adds ability to optionally override `multiArch` property of the `DeployableContainerBuilder.groovy` class should we have a need to in certain CI environments via `-PmultiArchSupport` cli flag