### PR TITLE
CORE-7096: Configurable Docker Target Platform

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,10 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('multiArchSupport')) {
         multiArch = multiArchSupport.toBoolean()
     }
+    if (project.hasProperty('targetPlatform')) {
+        targetPlatform = project.property('targetPlatform').toString()
+    }
+
     setEntry = true
 }
 

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -137,7 +137,13 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<Boolean> multiArch =
-            getObjects().property(Boolean).convention(true)           
+            getObjects().property(Boolean).convention(true)
+
+    @Input
+    @Optional
+    // Force Target Platform, using format "operatingSystem/architecture"
+    final Property<String> targetPlatform =
+            getObjects().property(String).convention('')
 
     DeployableContainerBuilder() {
         description = 'Creates a new "corda-dev" image with the file specified in "overrideFilePath".'
@@ -227,7 +233,11 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         builder.addEnvironmentVariable('ENABLE_LOG4J2_DEBUG', 'false')
         builder.addEnvironmentVariable('CONSOLE_LOG_LEVEL', 'info')
 
-        if (System.getenv().containsKey("JENKINS_URL") && multiArch.get()) {
+        if (!targetPlatform.get().empty) {
+            logger.quiet("Forcing Jib to use ${targetPlatform.get()} platform")
+            String[] osArch = targetPlatform.get().split("/")
+            builder.setPlatforms(Set.of(new Platform(osArch[1], osArch[0])))
+        } else if (System.getenv().containsKey("JENKINS_URL") && multiArch.get()) {
             logger.quiet("Running on CI server - producing arm64 and amd64 images, property multiArch is ${multiArch.get()}")
             builder.addPlatform("arm64","linux")
         } else if (System.properties['os.arch'] == "aarch64") { 


### PR DESCRIPTION
Add 'targetPlatform' property to 'DeployableContainerBuilder' so
consumers can manually choose target platform for images built through
the 'publishOSGiImage' gradle task.
