### PR TITLE
NOTICK: Override Cron on alpha Branch so not to build nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 cordaPipeline(
     runIntegrationTests: false,
     publishOSGiImage: true,
-    dailyBuildCron: 'H 03 * * *',
+    dailyBuildCron: '',
     publishRepoPrefix: 'engineering-tools-maven',
     nexusAppId: 'net.corda-cli-host-0.0.1',
     publishToMavenS3Repository: true


### PR DESCRIPTION
Alpha has shipped no need to build this nightly, Setting this as a blank string to override default release/* branch behavior regarding building nightly