### PR TITLE
CORE-4935 add Buildkit integration as an alternative to JIB for creation of docker images

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -6,5 +6,6 @@ cordaPipeline(
     dailyBuildCron: 'H 02 * * *',
     publishOSGiImage: true,
     gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',
-    generateSbom: true
+    generateSbom: true,
+    buildDockerImages: "publishBuildkitImage",
     )

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@jansz/CORE-4935/buildkit-nightly') _
 
 cordaPipeline(
     nexusAppId: 'net.corda-api-5.0',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
+@Library('corda-shared-build-pipeline-steps@jansz/CORE-4935/buildkit-nightly') _
 
 cordaPipeline(
     runIntegrationTests: false,

--- a/README.md
+++ b/README.md
@@ -51,3 +51,46 @@ You can add these flags as Java Parameters before the jar file is called.
 
 You can also change the plugin directory by editing the following in the corda-cli.cmd/sh files:
 - `-Dpf4j.pluginsDir`— changes the directory plugins are loaded from.
+
+## Creating Docker Images using Buildkit
+
+Another task have been provided to build docker images. The `publishBuildkitImage` task inherits most of it’s functionality and structure from `publishOSGiImage`, but also provides better caching and speed to the builds. It uses BuildKit to create and publish docker images to specified repositories. 
+
+Depending on which way the buildkit is used, the task can be run in two ways:
+
+### Docker buildx
+This version of buildkit has been integrated into docker and comes preinstalled with docker engine. This way is more favourable to developers as it requires no initial setup and provides most of the preferred functionality, mainly local caching of image layers.
+
+### Buildctl with dedicated buildkit daemon
+The standalone buildkit client buildctl provides the same functionality as buildx but also uses remote cache. The build is run through a buildkit daemon available on `eks-e2e` cluster. 
+
+To use standalone buildkit, it's client buildctl needs to be installed.
+
+For Mac the client can be installed using homebrew
+
+```
+brew install buildkit
+```
+
+Otherwise, it can be installed from source: 
+
+```
+git clone git@github.com:moby/buildkit.git buildkit
+cd buildkit
+make && sudo make install
+```
+
+The standalone buildkit requires a remote buildkit daemon to run. To connect to a buildkit daemon, developer has to log into `eke-e2e` cluster and port forward the daemon to port 3465.
+
+```
+aws --profile "${AWS_PROFILE}" eks update-kubeconfig --name eks-e2e
+kubectl port-forward deployment/buildkit 3476:3476
+```
+
+Only after buildctlis installed and buildkit daemon is connected, publishBuildkitImage task can be used with standalone buildkit by setting the  useBuildx parameter to false.
+
+```
+ gradlew publishBuildkitImage -PuseBuildkit=false
+```
+
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,23 @@ def cordaCLi = tasks.named('jar', Jar) {
     archiveVersion = project.version
 }
 
+tasks.register('publishBuildkitImage', BuildkitBuild) {
+    sourceTasks = Arrays.asList(cordaCLi.get())
+    dependsOn(cordaCLi)
+    overrideEntryName = 'cli'
+    containerName = 'cli'
+    arguments = Arrays.asList("-Dpf4j.pluginsDir=/opt/override/plugins")
+    if (project.hasProperty('baseImage')) {
+        baseImageName = baseImage
+    }
+    if (project.hasProperty('isNightly')) {
+        nightlyBuild = isNightly.toBoolean()
+    }
+    if (project.hasProperty('workerBaseImageTag')) {
+        baseImageTag = workerBaseImageTag
+    }
+}
+
 tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     sourceTasks = Arrays.asList(cordaCLi.get())
     dependsOn(cordaCLi)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ tasks.named("run") {
 def cordaCLi = tasks.named('jar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
-    from (sourceSets.main.output)
+    from(sourceSets.main.output)
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
@@ -76,6 +76,9 @@ def cordaCLi = tasks.named('jar', Jar) {
     archiveBaseName = 'corda-cli'
     archiveVersion = project.version
 }
+
+// Proposed alternative to publishOSGiImage
+// Currently in trial phase, being rolled out in Nightly and locally and planned to be deployed in phases down the line
 
 tasks.register('publishBuildkitImage', BuildkitBuild) {
     sourceTasks = Arrays.asList(cordaCLi.get())
@@ -172,18 +175,18 @@ publishing {
             version = project.version
         }
     }
-    
+
     if (project.hasProperty('maven.repo.s3') && project.hasProperty('releasable')) {
-            repositories {
-                maven {
-                    name = 'AWS'
-                    url = project.findProperty('maven.repo.s3')
-                    credentials(AwsCredentials) {
-                        accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
-                        secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
-                        sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
-                    }
+        repositories {
+            maven {
+                name = 'AWS'
+                url = project.findProperty('maven.repo.s3')
+                credentials(AwsCredentials) {
+                    accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                    secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                    sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
                 }
             }
+        }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,6 +97,9 @@ tasks.register('publishBuildkitImage', BuildkitBuild) {
     if (project.hasProperty('useBuildx')) {
         isBuildx = useBuildx.toBoolean()
     }
+    if (project.hasProperty('appendTag')) {
+        appendContainerTag = appendTag
+    }
     if (project.hasProperty('tag')) {
         containerTag = tag
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,6 @@ def cordaCLi = tasks.named('jar', Jar) {
 
 // Proposed alternative to publishOSGiImage
 // Currently in trial phase, being rolled out in Nightly and locally and planned to be deployed in phases down the line
-
 tasks.register('publishBuildkitImage', BuildkitBuild) {
     sourceTasks = Arrays.asList(cordaCLi.get())
     dependsOn(cordaCLi)
@@ -94,6 +93,15 @@ tasks.register('publishBuildkitImage', BuildkitBuild) {
     }
     if (project.hasProperty('workerBaseImageTag')) {
         baseImageTag = workerBaseImageTag
+    }
+    if (project.hasProperty('useBuildx')) {
+        it.isBuildx = useBuildx.toBoolean()
+    }
+    if (project.hasProperty('tag')) {
+        it.containerTag = tag
+    }
+    if (project.hasProperty('repo')) {
+        it.containerRepo = repo
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,13 +95,16 @@ tasks.register('publishBuildkitImage', BuildkitBuild) {
         baseImageTag = workerBaseImageTag
     }
     if (project.hasProperty('useBuildx')) {
-        it.isBuildx = useBuildx.toBoolean()
+        isBuildx = useBuildx.toBoolean()
     }
     if (project.hasProperty('tag')) {
-        it.containerTag = tag
+        containerTag = tag
     }
     if (project.hasProperty('repo')) {
-        it.containerRepo = repo
+        containerRepo = repo
+    }
+    if (project.hasProperty('publishToDockerDaemon')) {
+        useDockerDaemon = publishToDockerDaemon.toBoolean()
     }
 }
 

--- a/buildSrc/src/main/groovy/BuildkitBuild.groovy
+++ b/buildSrc/src/main/groovy/BuildkitBuild.groovy
@@ -1,0 +1,352 @@
+import org.gradle.api.tasks.Exec
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.Optional
+import org.gradle.api.provider.ProviderFactory
+import static org.gradle.api.tasks.PathSensitivity.RELATIVE
+import org.gradle.api.Task
+import javax.inject.Inject
+import java.net.Socket
+import java.text.SimpleDateFormat
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+/**
+ *  Task to publish worker images to artifactory using buildkit
+ *  https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4063035406/BuildKit
+ */
+
+abstract class BuildkitBuild extends Exec {
+
+    private final String projectName = project.name
+    private final String version = project.version
+    private def gitTask
+    private def gitLogTask
+    private def releaseType
+
+    @Inject
+    protected abstract ObjectFactory getObjects()
+
+    @Inject
+    protected abstract ProviderFactory getProviderFactory()
+
+    // Credentials used for authentication to docker and artifactory
+    @Input
+    @Optional
+    final Property<String> registryUsername = getObjects().property(String).
+            convention(getProviderFactory().environmentVariable("CORDA_ARTIFACTORY_USERNAME")
+                    .orElse(getProviderFactory().gradleProperty("cordaArtifactoryUsername"))
+                    .orElse(getProviderFactory().systemProperty("corda.artifactory.username"))
+            )
+
+    @Input
+    @Optional
+    final Property<String> registryPassword = getObjects().property(String).
+            convention(getProviderFactory().environmentVariable("CORDA_ARTIFACTORY_PASSWORD")
+                    .orElse(getProviderFactory().gradleProperty("cordaArtifactoryPassword"))
+                    .orElse(getProviderFactory().systemProperty("corda.artifactory.password"))
+            )
+
+    // Handles to determind build type
+    @Input
+    final Property<Boolean> releaseCandidate =
+            getObjects().property(Boolean).convention(false)
+
+    @Input
+    final Property<Boolean> nightlyBuild =
+            getObjects().property(Boolean).convention(false)
+
+    @Input
+    final Property<Boolean> preTest =
+            getObjects().property(Boolean).convention(false)
+
+    // Handle to set the build tool used to create an image
+    // Currently supported tools are docker buildx and native builkit 
+    // NOTE: native buidkit requires port forwarding to the aws buildkit cluster
+    @Input
+    final Property<Boolean> isBuildx =
+            getObjects().property(Boolean).convention(true)
+
+    // Handle for loading images into docker
+    @Input
+    final Property<Boolean> useDocker =
+            getObjects().property(Boolean).convention(false)
+
+    @Input
+    final Property<Boolean> useShortName =
+            getObjects().property(Boolean).convention(false)
+
+    // Handle to set the output image's repository:name:tag
+    @Input 
+    final Property<String> containerRepo =
+            getObjects().property(String).convention('')
+
+    @Input
+    final Property<String> containerTag =
+            getObjects().property(String).convention('')
+
+    @Input
+    final Property<String> containerName =
+            getObjects().property(String).convention('')
+
+    // Handles to set the base image's name:tag
+    @Input
+    final Property<String> baseImageName =
+            getObjects().property(String).convention('azul/zulu-openjdk')
+
+    @Input
+    final Property<String> baseImageTag =
+            getObjects().property(String).convention('11')
+    
+    // Arguments passed to the image entrypoint
+    @Input
+    final ListProperty<String> arguments =
+            getObjects().listProperty(String)
+
+    @Input
+    final ListProperty<Task> sourceTasks =
+            getObjects().listProperty(Task)
+
+    // Files generated in the build that need to be inside the container
+    @PathSensitive(RELATIVE)
+    @InputFiles
+    final ConfigurableFileCollection extraSourceFiles =
+            getObjects().fileCollection()
+
+    @PathSensitive(RELATIVE)
+    @InputFiles
+    final ConfigurableFileCollection jdbcDriverFiles =
+            getObjects().fileCollection()
+
+    // Used to create a folder for plugins in tools:plugins task
+    @Input
+    final Property<String> subDir =
+            getObjects().property(String).convention('')
+
+    // Overrides name of the jar file being executed at the entrypoint
+    @Input
+    final Property<String> overrideEntryName =
+            getObjects().property(String).convention('')
+
+    // Publishing to dockerhub
+    @Input
+    final Property<Boolean> dockerHubPublish =
+            getObjects().property(Boolean).convention(false)
+
+    BuildkitBuild() {
+        group = 'publishing'
+
+        if(!isBuildx){
+            try {
+            (new Socket('127.0.0.1', 3476)).close();
+            logger.quiet("Buildkit daemon found")
+            }
+            catch (SocketException e) {
+                throw new GradleException("No daemon found. Please connect to available buildkit daemon (and port forward it to 3476) and start again")
+            }
+        }
+        
+        gitTask = project.tasks.register("gitVersion", GetLatestGitRevision.class)
+        super.dependsOn(gitTask)
+
+        gitLogTask = project.tasks.register("gitMessageTask", getLatestGitCommitMessage.class)
+        super.dependsOn(gitLogTask)
+
+        if (System.getenv("RELEASE_TYPE")?.trim()) {
+            releaseType = System.getenv("RELEASE_TYPE")
+            logger.quiet("Using Release Type : '${releaseType}")
+        }
+    }
+
+    @Override
+    @TaskAction
+    protected void exec() {
+
+        def buildBaseDir = temporaryDir.toPath()
+        def sourceFiles = sourceTasks.get().collect{ it -> it.getOutputs().files.files }.flatten() as List<File>
+        def containerizationDir = Paths.get("$buildBaseDir/containerization/")
+        def driverDir = Paths.get("$buildBaseDir/jdbc-driver/")
+        def containerLocation = '/opt/override/'
+        def driverLocation = '/opt/jdbc-driver'
+        def timeStamp = new SimpleDateFormat("ddMMyy").format(new Date())
+        String tagPrefix = ""
+        def imageRepo = []
+        def targetRepo = ""
+        def targetTags = []
+        def dockerAuth = ['docker-remotes.software.r3.com', 'corda-os-docker.software.r3.com']
+
+        String gitRevision = gitTask.flatMap { it.revision }.get().replace("\n", "")
+
+        if (!(Files.exists(containerizationDir))) {
+            logger.quiet("Created containerization dir")
+            Files.createDirectories(containerizationDir)
+        }
+
+        if (!(Files.exists(driverDir))) {
+            logger.quiet("Created jdbc-driver dir")
+            Files.createDirectories(driverDir)
+        }
+
+        def names = []
+
+        (sourceFiles+ extraSourceFiles).forEach {
+            if (Files.exists(Paths.get(it.path))) {
+                Files.copy(Paths.get(it.path), Paths.get("${containerizationDir.toString()}/$it.name"), StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+        jdbcDriverFiles.forEach {
+            if (Files.exists(Paths.get(it.path))) {
+                Files.copy(Paths.get(it.path), Paths.get("${driverDir.toString()}/$it.name"), StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+
+        if(!containerRepo.get().isEmpty()){
+            targetRepo="${containerRepo.get()}"
+            if (!containerTag.get().isEmpty()) {
+                targetTags = ["${containerTag.get()}"]
+                imageRepo.add([name: targetRepo, tag: targetTags])
+            } else {
+                imageRepo.add([name: targetRepo, tag: ""])
+            }
+        } else if (dockerHubPublish.get()) {
+            targetRepo = "corda"
+            targetTags = ["${version}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (preTest.get()) {
+            targetRepo = "corda-os-docker-pre-test.software.r3.com"
+            targetTags = ["preTest-${tagPrefix}${version}", "preTest-${tagPrefix}${gitRevision}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (releaseType == 'RC' || releaseType == 'GA') {
+            targetRepo = "corda-os-docker-stable.software.r3.com"
+            targetTags = ["${tagPrefix}latest", "${tagPrefix}${version}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
+            targetRepo = "corda-os-docker-unstable.software.r3.com"
+            targetTags = ["${tagPrefix}unstable", "${tagPrefix}${gitRevision}", "${version}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
+            targetRepo = "corda-os-docker-dev.software.r3.com"
+            targetTags = ["${tagPrefix}${gitRevision}", "${version}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (releaseType == 'BETA' && nightlyBuild.get()) {
+            targetRepo = "corda-os-docker-nightly.software.r3.com"
+            targetTags = ["${tagPrefix}nightly", "${tagPrefix}nightly-${timeStamp}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else if (releaseType == 'ALPHA' && nightlyBuild.get()) {
+            targetRepo = "corda-os-docker-nightly.software.r3.com"
+            targetTags = ["${tagPrefix}nightly-${version}", "${tagPrefix}nightly-${gitRevision}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        } else {
+            targetRepo = "corda-os-docker-dev.software.r3.com"
+            targetTags = ["latest-local", "${version}", "${gitRevision}"]
+            imageRepo.add([name: targetRepo, tag: targetTags])
+        }
+
+        List<String> javaArgs = new ArrayList<String>(arguments.get())
+        javaArgs.add("-Dlog4j2.debug=\${ENABLE_LOG4J2_DEBUG:-false}")
+        javaArgs.add("-Dlog4j.configurationFile=log4j2-console.xml")
+        javaArgs.add("-Dpf4j.pluginsDir=${containerLocation + subDir.get()}")
+
+        def baseImageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
+        def entryName = overrideEntryName.get().empty ? projectName : overrideEntryName.get()
+
+        dockerAuth.add(targetRepo)
+
+        for (repo in dockerAuth) {
+            String[] cmd = ['docker', 'login', "${repo}", "-u ${registryUsername.get()}", "-p ${registryPassword.get()}"]
+            ExecShellCommand(cmd)
+        }
+
+        String[] baseCommand = []
+        String[] opts = []
+        String[] commandTail = []
+
+        workingDir project.rootDir
+
+        for (repo in imageRepo) {
+            for (tag in repo.tag) {
+                if(isBuildx.get()){
+                    logger.info("\nUsing docker Buildx\n")
+                    baseCommand = ['docker', 'buildx', "build", "--file ./docker/Dockerfile"]
+                    opts = ["--build-arg BASE_IMAGE=${baseImageName}", "--build-arg BUILD_PATH=${containerizationDir.toString().replace("${project.rootDir}",".")}", "--build-arg JAR_LOCATION=${containerLocation + subDir.get()}", "--build-arg JDBC_PATH=${driverDir.toString().replace("${project.rootDir}",".")}", "--build-arg JDBC_DRIVER_LOCATION=${driverLocation}", "--build-arg IMAGE_ENTRYPOINT=\"exec java ${javaArgs.join(" ")} -jar  ${containerLocation}*${entryName}**.jar\" "]
+                    commandTail = ["--${useDocker.get() ? "load" : "push"}", "--tag ${repo.name}/corda-os-${containerName.get()}:${tag}", "--cache-from ${repo.name}/corda-os-${containerName.get()}-cache", "--cache-to type=registry,ref=${repo.name}/corda-os-${containerName.get()}-cache", "."]
+                } else {
+                    logger.info("\nUsing native buildkit client\n")
+                    baseCommand = ['buildctl', "--addr tcp://localhost:3476", "build", "--frontend=dockerfile.v0", "--local context=/", "--local dockerfile=${project.rootDir.toString() + "/docker"}"]
+                    opts = ["--opt build-arg:BASE_IMAGE=${baseImageName}", "--opt build-arg:BUILD_PATH=${containerizationDir}", "--opt build-arg:JAR_LOCATION=${containerLocation + subDir.get()}", "--opt build-arg:JDBC_PATH=${driverDir}", "--opt build-arg:JDBC_DRIVER_LOCATION=${driverLocation}", "--opt build-arg:IMAGE_ENTRYPOINT=\"exec java ${javaArgs.join(" ")} -jar  ${containerLocation}*${entryName}**.jar\" "]
+                    commandTail = ["--output type=${useDocker.get() ? "docker" : "image"},name=${repo.name}/corda-os-${containerName.get()}:${tag}${useDocker.get() ? "" : ",push=true"}", "--export-cache type=registry,ref=${repo.name}/corda-os-${containerName.get()}-cache", "--import-cache type=registry,ref=${repo.name}/corda-os-${containerName.get()}-cache${useDocker.get() ? " | docker load" : ""}"]
+                }
+
+                String[] buildkitCommand = baseCommand + opts + commandTail
+
+                logger.info("${buildkitCommand.join('\n')}")
+
+                ExecShellCommand(buildkitCommand)
+            }
+        }
+
+    }
+
+    /**
+     * Helper task to retrieve get the latest git hash
+     */
+    static class GetLatestGitRevision extends Exec {
+        @Internal
+        final Property<String> revision
+
+        @Inject
+        GetLatestGitRevision(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'rev-parse', '--verify', '--short', 'HEAD'
+            standardOutput = new ByteArrayOutputStream()
+            revision = objects.property(String).value(
+                    providers.provider { standardOutput.toString() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve the latest git log message
+     */
+    static class getLatestGitCommitMessage extends Exec {
+        @Internal
+        final Property<String> message
+
+        @Inject
+        getLatestGitCommitMessage(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'log', '-1', '--oneline', '--format=%s'
+
+            standardOutput = new ByteArrayOutputStream()
+            message = objects.property(String).value(
+                    providers.provider { standardOutput.toString() }
+            )
+        }
+    }
+
+    private void ExecShellCommand(String[] Command) {
+        String systemCommand
+        String systemPrefix
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            systemCommand = 'powershell'
+            systemPrefix = '/c'
+        } else {
+            systemCommand = 'bash'
+            systemPrefix = '-c'
+        }
+
+        commandLine systemCommand, systemPrefix, Command.join(" ")
+        super.exec()
+    }
+}

--- a/buildSrc/src/main/groovy/BuildkitBuild.groovy
+++ b/buildSrc/src/main/groovy/BuildkitBuild.groovy
@@ -282,22 +282,22 @@ abstract class BuildkitBuild extends Exec {
             targetTags = ["${version}"]
         } else if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com"
-            targetTags = ["preTest-${tagPrefix}${version}", "preTest-${tagPrefix}${gitRevision}"]
+            targetTags = ["preTest-${version}", "preTest-${gitRevision}"]
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com"
-            targetTags = ["${tagPrefix}latest", "${tagPrefix}${version}"]
+            targetTags = ["latest", "${version}"]
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com"
-            targetTags = ["${tagPrefix}unstable", "${tagPrefix}${gitRevision}", "${version}"]
+            targetTags = ["unstable", "${gitRevision}", "${version}"]
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com"
-            targetTags = ["${tagPrefix}${gitRevision}", "${version}"]
+            targetTags = ["${gitRevision}", "${version}"]
         } else if (releaseType == 'BETA' && nightlyBuild.get()) {
             targetRepo = "corda-os-docker-nightly.software.r3.com"
-            targetTags = ["${tagPrefix}nightly", "${tagPrefix}nightly-${new SimpleDateFormat("ddMMyy").format(new Date())}"]
+            targetTags = ["nightly", "nightly-${new SimpleDateFormat("ddMMyy").format(new Date())}"]
         } else if (releaseType == 'ALPHA' && nightlyBuild.get()) {
             targetRepo = "corda-os-docker-nightly.software.r3.com"
-            targetTags = ["${tagPrefix}nightly-${version}", "${tagPrefix}nightly-${gitRevision}"]
+            targetTags = ["$nightly-${version}", "$nightly-${gitRevision}"]
         } else {
             targetRepo = "corda-os-docker-dev.software.r3.com"
             targetTags = ["latest-local", "${version}", "${gitRevision}"]

--- a/buildSrc/src/main/groovy/BuildkitBuild.groovy
+++ b/buildSrc/src/main/groovy/BuildkitBuild.groovy
@@ -57,62 +57,68 @@ abstract class BuildkitBuild extends Exec {
                     .orElse(getProviderFactory().systemProperty("corda.artifactory.password"))
             )
 
-    // Handles to determind build type
+    // Property to set images for release 
     @Input
     final Property<Boolean> releaseCandidate =
             getObjects().property(Boolean).convention(false)
 
+    //Property for nightly builds
     @Input
     final Property<Boolean> nightlyBuild =
             getObjects().property(Boolean).convention(false)
 
+    // Property for pre-test
     @Input
     final Property<Boolean> preTest =
             getObjects().property(Boolean).convention(false)
 
-    // Handle to set the build tool used to create an image
+    // Property to set the build tool used to create an image
     // Currently supported tools are docker buildx and native builkit 
     // NOTE: native buidkit requires port forwarding to the aws buildkit cluster
     @Input
     final Property<Boolean> isBuildx =
             getObjects().property(Boolean).convention(true)
 
-    // Handle for loading images into docker
+    // Property for loading images into docker
     @Input
     final Property<Boolean> useDocker =
             getObjects().property(Boolean).convention(false)
 
+    // The images contain shortened filenames if true
     @Input
     final Property<Boolean> useShortName =
             getObjects().property(Boolean).convention(false)
 
-    // Handle to set the output image's repository:name:tag
-    @Input 
+    // Property to set the output image's repository
+    @Input
     final Property<String> containerRepo =
             getObjects().property(String).convention('')
 
+    // Property used to set custom image tag
     @Input
     final Property<String> containerTag =
             getObjects().property(String).convention('')
 
+    // Property used to set custom image name
     @Input
     final Property<String> containerName =
             getObjects().property(String).convention('')
 
-    // Handles to set the base image's name:tag
+    // Property to set the base image's name
     @Input
     final Property<String> baseImageName =
             getObjects().property(String).convention('azul/zulu-openjdk')
-
+    // Property to set the base image's tag
     @Input
     final Property<String> baseImageTag =
             getObjects().property(String).convention('11')
-    
+
     // Arguments passed to the image entrypoint
     @Input
     final ListProperty<String> arguments =
             getObjects().listProperty(String)
 
+    // Tasklist to get the sourcefiles from
     @Input
     final ListProperty<Task> sourceTasks =
             getObjects().listProperty(Task)
@@ -123,6 +129,7 @@ abstract class BuildkitBuild extends Exec {
     final ConfigurableFileCollection extraSourceFiles =
             getObjects().fileCollection()
 
+    // JDBC driver files generated in the build that need to be inside the container
     @PathSensitive(RELATIVE)
     @InputFiles
     final ConfigurableFileCollection jdbcDriverFiles =
@@ -146,16 +153,16 @@ abstract class BuildkitBuild extends Exec {
     BuildkitBuild() {
         group = 'publishing'
 
-        if(!isBuildx){
+        if (!isBuildx) {
             try {
-            (new Socket('127.0.0.1', 3476)).close();
-            logger.quiet("Buildkit daemon found")
+                (new Socket('127.0.0.1', 3476)).close();
+                logger.quiet("Buildkit daemon found")
             }
             catch (SocketException e) {
                 throw new GradleException("No daemon found. Please connect to available buildkit daemon (and port forward it to 3476) and start again")
             }
         }
-        
+
         gitTask = project.tasks.register("gitVersion", GetLatestGitRevision.class)
         super.dependsOn(gitTask)
 
@@ -173,7 +180,7 @@ abstract class BuildkitBuild extends Exec {
     protected void exec() {
 
         def buildBaseDir = temporaryDir.toPath()
-        def sourceFiles = sourceTasks.get().collect{ it -> it.getOutputs().files.files }.flatten() as List<File>
+        def sourceFiles = sourceTasks.get().collect { it -> it.getOutputs().files.files }.flatten() as List<File>
         def containerizationDir = Paths.get("$buildBaseDir/containerization/")
         def driverDir = Paths.get("$buildBaseDir/jdbc-driver/")
         def containerLocation = '/opt/override/'
@@ -199,7 +206,7 @@ abstract class BuildkitBuild extends Exec {
 
         def names = []
 
-        (sourceFiles+ extraSourceFiles).forEach {
+        (sourceFiles + extraSourceFiles).forEach {
             if (Files.exists(Paths.get(it.path))) {
                 Files.copy(Paths.get(it.path), Paths.get("${containerizationDir.toString()}/$it.name"), StandardCopyOption.REPLACE_EXISTING)
             }
@@ -211,8 +218,8 @@ abstract class BuildkitBuild extends Exec {
             }
         }
 
-        if(!containerRepo.get().isEmpty()){
-            targetRepo="${containerRepo.get()}"
+        if (!containerRepo.get().isEmpty()) {
+            targetRepo = "${containerRepo.get()}"
             if (!containerTag.get().isEmpty()) {
                 targetTags = ["${containerTag.get()}"]
                 imageRepo.add([name: targetRepo, tag: targetTags])
@@ -255,8 +262,6 @@ abstract class BuildkitBuild extends Exec {
 
         List<String> javaArgs = new ArrayList<String>(arguments.get())
         javaArgs.add("-Dlog4j2.debug=\${ENABLE_LOG4J2_DEBUG:-false}")
-        javaArgs.add("-Dlog4j.configurationFile=log4j2-console.xml")
-        javaArgs.add("-Dpf4j.pluginsDir=${containerLocation + subDir.get()}")
 
         def baseImageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
         def entryName = overrideEntryName.get().empty ? projectName : overrideEntryName.get()
@@ -276,10 +281,10 @@ abstract class BuildkitBuild extends Exec {
 
         for (repo in imageRepo) {
             for (tag in repo.tag) {
-                if(isBuildx.get()){
+                if (isBuildx.get()) {
                     logger.info("\nUsing docker Buildx\n")
                     baseCommand = ['docker', 'buildx', "build", "--file ./docker/Dockerfile"]
-                    opts = ["--build-arg BASE_IMAGE=${baseImageName}", "--build-arg BUILD_PATH=${containerizationDir.toString().replace("${project.rootDir}",".")}", "--build-arg JAR_LOCATION=${containerLocation + subDir.get()}", "--build-arg JDBC_PATH=${driverDir.toString().replace("${project.rootDir}",".")}", "--build-arg JDBC_DRIVER_LOCATION=${driverLocation}", "--build-arg IMAGE_ENTRYPOINT=\"exec java ${javaArgs.join(" ")} -jar  ${containerLocation}*${entryName}**.jar\" "]
+                    opts = ["--build-arg BASE_IMAGE=${baseImageName}", "--build-arg BUILD_PATH=${containerizationDir.toString().replace("${project.rootDir}", ".")}", "--build-arg JAR_LOCATION=${containerLocation + subDir.get()}", "--build-arg JDBC_PATH=${driverDir.toString().replace("${project.rootDir}", ".")}", "--build-arg JDBC_DRIVER_LOCATION=${driverLocation}", "--build-arg IMAGE_ENTRYPOINT=\"exec java ${javaArgs.join(" ")} -jar  ${containerLocation}*${entryName}**.jar\" "]
                     commandTail = ["--${useDocker.get() ? "load" : "push"}", "--tag ${repo.name}/corda-os-${containerName.get()}:${tag}", "--cache-from ${repo.name}/corda-os-${containerName.get()}-cache", "--cache-to type=registry,ref=${repo.name}/corda-os-${containerName.get()}-cache", "."]
                 } else {
                     logger.info("\nUsing native buildkit client\n")

--- a/buildSrc/src/main/groovy/BuildkitBuild.groovy
+++ b/buildSrc/src/main/groovy/BuildkitBuild.groovy
@@ -25,7 +25,6 @@ import java.nio.file.StandardCopyOption
  *  Task to publish worker images to artifactory using buildkit
  *  https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4063035406/BuildKit
  */
-
 abstract class BuildkitBuild extends Exec {
 
     private final String projectName = project.name
@@ -59,96 +58,79 @@ abstract class BuildkitBuild extends Exec {
 
     // Property to set images for release 
     @Input
-    final Property<Boolean> releaseCandidate =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> releaseCandidate = getObjects().property(Boolean).convention(false)
 
     //Property for nightly builds
     @Input
-    final Property<Boolean> nightlyBuild =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> nightlyBuild = getObjects().property(Boolean).convention(false)
 
     // Property for pre-test
     @Input
-    final Property<Boolean> preTest =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> preTest = getObjects().property(Boolean).convention(false)
 
     // Property to set the build tool used to create an image
     // Currently supported tools are docker buildx and native builkit 
     // NOTE: native buidkit requires port forwarding to the aws buildkit cluster
     @Input
-    final Property<Boolean> isBuildx =
-            getObjects().property(Boolean).convention(true)
+    final Property<Boolean> isBuildx = getObjects().property(Boolean).convention(true)
 
     // Property for loading images into docker
     @Input
-    final Property<Boolean> useDocker =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> useDocker = getObjects().property(Boolean).convention(false)
 
     // The images contain shortened filenames if true
     @Input
-    final Property<Boolean> useShortName =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> useShortName = getObjects().property(Boolean).convention(false)
 
     // Property to set the output image's repository
     @Input
-    final Property<String> containerRepo =
-            getObjects().property(String).convention('')
+    final Property<String> containerRepo = getObjects().property(String).convention('')
 
     // Property used to set custom image tag
     @Input
-    final Property<String> containerTag =
-            getObjects().property(String).convention('')
+    final Property<String> containerTag = getObjects().property(String).convention('')
 
     // Property used to set custom image name
     @Input
-    final Property<String> containerName =
-            getObjects().property(String).convention('')
+    final Property<String> containerName = getObjects().property(String).convention('')
 
     // Property to set the base image's name
     @Input
-    final Property<String> baseImageName =
-            getObjects().property(String).convention('azul/zulu-openjdk')
+    final Property<String> baseImageName = getObjects().property(String).convention('azul/zulu-openjdk')
+
     // Property to set the base image's tag
     @Input
-    final Property<String> baseImageTag =
-            getObjects().property(String).convention('11')
+    final Property<String> baseImageTag = getObjects().property(String).convention('11')
 
     // Arguments passed to the image entrypoint
     @Input
-    final ListProperty<String> arguments =
-            getObjects().listProperty(String)
+    final ListProperty<String> arguments = getObjects().listProperty(String)
 
     // Tasklist to get the sourcefiles from
     @Input
-    final ListProperty<Task> sourceTasks =
-            getObjects().listProperty(Task)
+    final ListProperty<Task> sourceTasks = getObjects().listProperty(Task)
 
     // Files generated in the build that need to be inside the container
     @PathSensitive(RELATIVE)
     @InputFiles
-    final ConfigurableFileCollection extraSourceFiles =
-            getObjects().fileCollection()
+    final ConfigurableFileCollection extraSourceFiles = getObjects().fileCollection()
 
     // JDBC driver files generated in the build that need to be inside the container
     @PathSensitive(RELATIVE)
     @InputFiles
-    final ConfigurableFileCollection jdbcDriverFiles =
-            getObjects().fileCollection()
+    final ConfigurableFileCollection jdbcDriverFiles = getObjects().fileCollection()
 
     // Used to create a folder for plugins in tools:plugins task
     @Input
-    final Property<String> subDir =
-            getObjects().property(String).convention('')
+    final Property<String> subDir = getObjects().property(String).convention('')
 
     // Overrides name of the jar file being executed at the entrypoint
     @Input
-    final Property<String> overrideEntryName =
-            getObjects().property(String).convention('')
+    final Property<String> overrideEntryName = getObjects().property(String).convention('')
 
     // Publishing to dockerhub
     @Input
-    final Property<Boolean> dockerHubPublish =
-            getObjects().property(Boolean).convention(false)
+    final Property<Boolean> dockerHubPublish = getObjects().property(Boolean).convention(false)
 
     BuildkitBuild() {
         group = 'publishing'
@@ -156,17 +138,19 @@ abstract class BuildkitBuild extends Exec {
         if (!isBuildx) {
             try {
                 (new Socket('127.0.0.1', 3476)).close();
-                logger.quiet("Buildkit daemon found")
+                logger.info("Buildkit daemon found")
             }
             catch (SocketException e) {
                 throw new GradleException("No daemon found. Please connect to available buildkit daemon (and port forward it to 3476) and start again")
             }
+        } else {
+            CheckForBuildxContainer()
         }
 
-        gitTask = project.tasks.register("gitVersion", GetLatestGitRevision.class)
+        gitTask = project.tasks.register("gitVersionBuildkit", GetLatestGitRevision.class)
         super.dependsOn(gitTask)
 
-        gitLogTask = project.tasks.register("gitMessageTask", getLatestGitCommitMessage.class)
+        gitLogTask = project.tasks.register("gitMessageTaskBuildkit", getLatestGitCommitMessage.class)
         super.dependsOn(gitLogTask)
 
         if (System.getenv("RELEASE_TYPE")?.trim()) {
@@ -190,7 +174,7 @@ abstract class BuildkitBuild extends Exec {
         def imageRepo = []
         def targetRepo = ""
         def targetTags = []
-        def dockerAuth = ['docker-remotes.software.r3.com', 'corda-os-docker.software.r3.com']
+        List<String> dockerAuth = new ArrayList<String>(['docker-remotes.software.r3.com', 'corda-os-docker.software.r3.com'])
 
         String gitRevision = gitTask.flatMap { it.revision }.get().replace("\n", "")
 
@@ -203,8 +187,6 @@ abstract class BuildkitBuild extends Exec {
             logger.quiet("Created jdbc-driver dir")
             Files.createDirectories(driverDir)
         }
-
-        def names = []
 
         (sourceFiles + extraSourceFiles).forEach {
             if (Files.exists(Paths.get(it.path))) {
@@ -268,14 +250,11 @@ abstract class BuildkitBuild extends Exec {
 
         dockerAuth.add(targetRepo)
 
-        for (repo in dockerAuth) {
-            String[] cmd = ['docker', 'login', "${repo}", "-u ${registryUsername.get()}", "-p ${registryPassword.get()}"]
-            ExecShellCommand(cmd)
-        }
+        DockerLogin(dockerAuth)
 
-        String[] baseCommand = []
-        String[] opts = []
-        String[] commandTail = []
+        String[] baseCommand
+        String[] opts
+        String[] commandTail
 
         workingDir project.rootDir
 
@@ -337,6 +316,26 @@ abstract class BuildkitBuild extends Exec {
             message = objects.property(String).value(
                     providers.provider { standardOutput.toString() }
             )
+        }
+    }
+
+    //check for buildx docker container driver and create a new one if not present
+    private void CheckForBuildxContainer() {
+        try {
+            String[] cmd = ['docker', 'buildx', 'use', 'container']
+            ExecShellCommand(cmd)
+        } catch (GradleException e) {
+            logger.info("no buildx container found, creating a fresh container")
+            String[] cmd = ['docker', 'buildx', 'create', '--name=container', '--driver=docker-container', '--use', '--bootstrap']
+            ExecShellCommand(cmd)
+        }
+    }
+
+    //log into docker repositiories in the list
+    private void DockerLogin(List<String> repositoryList) {
+        for (repo in repositoryList) {
+            String[] cmd = ['docker', 'login', "${repo}", "-u ${registryUsername.get()}", "-p ${registryPassword.get()}"]
+            ExecShellCommand(cmd)
         }
     }
 

--- a/buildSrc/src/main/groovy/BuildkitBuild.groovy
+++ b/buildSrc/src/main/groovy/BuildkitBuild.groovy
@@ -90,6 +90,10 @@ abstract class BuildkitBuild extends Exec {
     @Input
     final Property<String> containerTag = getObjects().property(String).convention('')
 
+    // Property used to append custom image tag
+    @Input
+    final Property<String> appendContainerTag = getObjects().property(String).convention('')
+
     // Property used to set custom image name
     @Input
     final Property<String> containerName = getObjects().property(String).convention('')
@@ -221,7 +225,7 @@ abstract class BuildkitBuild extends Exec {
         for (repo in imageRepo) {
             imageNames = new ArrayList()
             for (tag in repo.tag) {
-                imageNames.add("${repo.name}/corda-os-${containerName.get()}:${tag}")
+                imageNames.add("${repo.name}/corda-os-${containerName.get()}:${tag + appendContainerTag.get()}")
             }
 
             if (isBuildx.get()) {
@@ -270,44 +274,36 @@ abstract class BuildkitBuild extends Exec {
             targetRepo = "${containerRepo.get()}"
             if (!containerTag.get().isEmpty()) {
                 targetTags = ["${containerTag.get()}"]
-                imageRepo.add([name: targetRepo, tag: targetTags])
             } else {
                 targetTags = ["latest"]
-                imageRepo.add([name: targetRepo, tag: targetTags])
             }
         } else if (dockerHubPublish.get()) {
             targetRepo = "corda"
             targetTags = ["${version}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com"
             targetTags = ["preTest-${tagPrefix}${version}", "preTest-${tagPrefix}${gitRevision}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com"
             targetTags = ["${tagPrefix}latest", "${tagPrefix}${version}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com"
             targetTags = ["${tagPrefix}unstable", "${tagPrefix}${gitRevision}", "${version}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com"
             targetTags = ["${tagPrefix}${gitRevision}", "${version}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (releaseType == 'BETA' && nightlyBuild.get()) {
             targetRepo = "corda-os-docker-nightly.software.r3.com"
             targetTags = ["${tagPrefix}nightly", "${tagPrefix}nightly-${new SimpleDateFormat("ddMMyy").format(new Date())}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else if (releaseType == 'ALPHA' && nightlyBuild.get()) {
             targetRepo = "corda-os-docker-nightly.software.r3.com"
             targetTags = ["${tagPrefix}nightly-${version}", "${tagPrefix}nightly-${gitRevision}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         } else {
             targetRepo = "corda-os-docker-dev.software.r3.com"
             targetTags = ["latest-local", "${version}", "${gitRevision}"]
-            imageRepo.add([name: targetRepo, tag: targetTags])
         }
+
+        imageRepo.add([name: targetRepo, tag: targetTags])
 
         return imageRepo
     }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,20 +4,17 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 
-ARG IMAGE_ENTRYPOINT="exec java -Dlog4j2.debug=false -Dlog4j.configurationFile=log4j2-console.xml -jar /opt/override/crypto.jar"
-ARG BUILD_PATH="/applications/workers/release/crypto-worker/build/tmp/publishOSGiImage/containerization/corda-crypto-worker-5.0.0.0-SNAPSHOT.jar"
-ARG JDBC_PATH="/applications/workers/release/crypto-worker/build/tmp/publishOSGiImage/jdbc-driver"
-ARG JAR_LOCATION="/opt/override/"
-ARG JDBC_DRIVER_LOCATION="/opt/jdbc-driver/"
+ARG IMAGE_ENTRYPOINT
+ARG BUILD_PATH
+ARG JDBC_PATH
+ARG JAR_LOCATION
+ARG JDBC_DRIVER_LOCATION
 
 ENV IMAGE_ENTRYPOINT_ENV=${IMAGE_ENTRYPOINT}
 ENV CORDA_BASE="/opt/override"
 ENV CORDA_CLI_HOME_DIR="/opt/override/home"
-ENV LOG4J_CONFIG_FILE="log4j2-console.xml"
-ENV JAVA_HOME="/usr/lib/jvm/zulu11-ca-amd64"
 ENV ENABLE_LOG4J2_DEBUG="false"
 ENV CONSOLE_LOG_LEVEL="INFO"
-ENV CORDA_CLI_HOME_DIR="/opt/override/home"
 
 ADD --chown=corda:corda ${BUILD_PATH} ${JAR_LOCATION}
 ADD --chown=corda:corda ${JDBC_PATH} ${JDBC_DRIVER_LOCATION} 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.4
+
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+ARG IMAGE_ENTRYPOINT="exec java -Dlog4j2.debug=false -Dlog4j.configurationFile=log4j2-console.xml -jar /opt/override/crypto.jar"
+ARG BUILD_PATH="/applications/workers/release/crypto-worker/build/tmp/publishOSGiImage/containerization/corda-crypto-worker-5.0.0.0-SNAPSHOT.jar"
+ARG JDBC_PATH="/applications/workers/release/crypto-worker/build/tmp/publishOSGiImage/jdbc-driver"
+ARG JAR_LOCATION="/opt/override/"
+ARG JDBC_DRIVER_LOCATION="/opt/jdbc-driver/"
+
+ENV IMAGE_ENTRYPOINT_ENV=${IMAGE_ENTRYPOINT}
+ENV CORDA_BASE="/opt/override"
+ENV CORDA_CLI_HOME_DIR="/opt/override/home"
+ENV LOG4J_CONFIG_FILE="log4j2-console.xml"
+ENV JAVA_HOME="/usr/lib/jvm/zulu11-ca-amd64"
+ENV ENABLE_LOG4J2_DEBUG="false"
+ENV CONSOLE_LOG_LEVEL="INFO"
+ENV CORDA_CLI_HOME_DIR="/opt/override/home"
+
+ADD --chown=corda:corda ${BUILD_PATH} ${JAR_LOCATION}
+ADD --chown=corda:corda ${JDBC_PATH} ${JDBC_DRIVER_LOCATION} 
+
+ENTRYPOINT ["bin/sh","-c","${IMAGE_ENTRYPOINT_ENV} $@","$@"]


### PR DESCRIPTION
**Description**
Currently docker images for C5 are produced by the framework `JIB`, this piece of work investigates leveraging Docker tools `Buidkit`, which is now integrated into docker desktop by standard for image creation. 

This PR is an extension of buildkit integration in `corda-runtime-os`.

The PR adds a new gradle task called `publishBuildkitImage`  to the cli-host deployment, which creates an image by passing a Docker file with arguments selected based on the image being created and the parameters specified by the user on the command line. The task was originally made based on the [DeployableContainerBuilder](https://github.com/corda/corda-runtime-os/blob/release/os/5.0/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy), and follows the same structure. The task has several parameters for customizing the image and its destination, including:

  - `baseImage` specifies the name of the base image being used to create the Docker container
  - `workerBaseImageTag` specifies the tag of the base image being used to create the Docker container
  - `repo` specifies the repository to which the new image will be published
  - `tag` specifies the tag the new image will be published with
  - `isNightly` publishes the image to corda-os-docker-nightly.software.r3.com
  - `isDocker` instead of publishing, the task loads the image into Docker
  - `useBuildx` uses a docker buildx to create the image instead of buildctl

As described with the last parameter, buildkit can be used in two ways. The standalone buildkit command tool `buildctl` or the `docker buildx` - a buildkit release already built into docker. Both versions have the same capabilities and features and are integrated into the task. 

BuildKit has a number of advantages including better support for image layering and caching. This piece of work will optionally add in a new way to generate these image's, for now keeping both the JIB and Build kit methods. Most Automation will continue to use the existing JIB framework, however we will slowly layer in BuildKit in some environments (i.e. nightlys) and some local volunteers while we continue to address suitability and stability.

More about Build kit and our use of it can be read here https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4063035406/BuildKit 

Accompanying PR's:
https://github.com/corda/corda-runtime-os/pull/2360
https://github.com/corda/corda-shared-build-pipeline-steps/pull/385

Jenkins passing build:
https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-cli-host/detail/PR-126/9/pipeline
