### PR TITLE
CORE-9787: Enable local build cache

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -121,15 +121,17 @@ include 'plugins:example'
 gradleEnterprise {
     server = gradleEnterpriseUrl
     allowUntrustedServer = false
+    def apiKey = settings.ext.find('CORDA_GRADLE_SCAN_KEY') ?: System.getenv('CORDA_GRADLE_SCAN_KEY')
+    def username = settings.ext.find('BUILD_CACHE_CREDENTIALS_USR') ?: System.getenv('BUILD_CACHE_CREDENTIALS_USR')
+    def password = settings.ext.find('BUILD_CACHE_CREDENTIALS_PSW') ?: System.getenv('BUILD_CACHE_CREDENTIALS_PSW')
+    accessKey = apiKey
     buildScan {
-        def apiKey = settings.ext.find('CORDA_GRADLE_SCAN_KEY') ?: System.getenv('CORDA_GRADLE_SCAN_KEY')
         if (apiKey?.trim()) {
             publishAlways()
             capture {
                 taskInputFiles = true
             }
             uploadInBackground = false
-            accessKey = apiKey
         }
     }
     buildCache {
@@ -137,19 +139,15 @@ gradleEnterprise {
             enabled = true
             removeUnusedEntriesAfterDays = 14  // Garbage collect if a cache item is not used in 2 weeks.
         }
-        remote(HttpBuildCache) {
-            url = "${gradleEnterpriseUrl}/cache/"
-            credentials {
-                username = settings.ext.find('BUILD_CACHE_CREDENTIALS_USR') ?: System.getenv('BUILD_CACHE_CREDENTIALS_USR')
-                password = settings.ext.find('BUILD_CACHE_CREDENTIALS_PSW') ?: System.getenv('BUILD_CACHE_CREDENTIALS_PSW')
-            }
+        remote(gradleEnterprise.buildCache) {
             // For the remote build cache we will populate cache only from Jenkins, all machines can pull from cache however.
             if (System.getenv().containsKey("JENKINS_URL")) {
+                usernameAndPassword(username,password)
                 push = true
                 enabled = true
             } else {
                 push = false
-                enabled = false
+                enabled = true
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -142,7 +142,6 @@ gradleEnterprise {
         remote(gradleEnterprise.buildCache) {
             // For the remote build cache we will populate cache only from Jenkins, all machines can pull from cache however.
             if (System.getenv().containsKey("JENKINS_URL")) {
-                usernameAndPassword(username,password)
                 push = true
                 enabled = true
             } else {

--- a/settings.gradle
+++ b/settings.gradle
@@ -122,8 +122,6 @@ gradleEnterprise {
     server = gradleEnterpriseUrl
     allowUntrustedServer = false
     def apiKey = settings.ext.find('CORDA_GRADLE_SCAN_KEY') ?: System.getenv('CORDA_GRADLE_SCAN_KEY')
-    def username = settings.ext.find('BUILD_CACHE_CREDENTIALS_USR') ?: System.getenv('BUILD_CACHE_CREDENTIALS_USR')
-    def password = settings.ext.find('BUILD_CACHE_CREDENTIALS_PSW') ?: System.getenv('BUILD_CACHE_CREDENTIALS_PSW')
     accessKey = apiKey
     buildScan {
         if (apiKey?.trim()) {


### PR DESCRIPTION
* Enable usage of build cache locally
* Implemented new identity access base using gradleEnterprise.buildCache
Local Test Result: https://gradle.dev.r3.com/s/ts6deaxwjtcow
Remote Test Result: https://gradle.dev.r3.com/scans?search.tags=pr-132&search.timeZoneId=Europe/London