### PR TITLE
NOTICK: ensure remote cache disable if not valid api key set

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -144,7 +144,7 @@ gradleEnterprise {
                 enabled = true
             } else {
                 push = false
-                enabled = true
+                enabled = apiKey?.trim() ? true : false
             }
         }
     }


### PR DESCRIPTION
if the needed env var CORDA_GRADLE_SCAN_KEY is not set simply set remote cache to false other wise true