### PR TITLE
INFRA-1894: switching build agent from EC2 instances to a Kubernetes pod

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,6 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
-cordaPipeline(
+cordaPipelineKubernetesAgent(
     nexusAppId: 'net.corda-api-5.0',
     runIntegrationTests: false,
     dailyBuildCron: 'H 02 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
-cordaPipeline(
+cordaPipelineKubernetesAgent(
     runIntegrationTests: false,
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',


### PR DESCRIPTION
* use newly introduced `cordaPipelineKubernetesAgent`, which is a drop in replacement of original `cordaPipeline` pipeline

- nightly: https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20Nightly%20Jobs/job/Nightlys/job/Corda-CLI-Plugin-Host/job/Linux/view/change-requests/job/PR-135/