### PR TITLE
CORE-10198: Upgrade to Kotlin 1.8.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = "net.corda.cli.host"
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     compileOnly "org.pf4j:pf4j:${pf4jVersion}"
     api "info.picocli:picocli:$picoCliVersion"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     implementation project(":api")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -63,15 +65,15 @@ subprojects {
     }
 
     tasks.withType(KotlinCompile).configureEach {
-        kotlinOptions {
-            languageVersion = '1.7'
-            apiVersion = '1.7'
+        compilerOptions {
+            languageVersion = KOTLIN_1_8
+            apiVersion = KOTLIN_1_8
+            jvmTarget = JVM_11
             verbose = true
-            jvmTarget = VERSION_11
-            freeCompilerArgs += [
-                "-Xjvm-default=all",
-                "-java-parameters"
-            ]
+            javaParameters = true
+            freeCompilerArgs.addAll([
+                "-Xjvm-default=all"
+            ])
         }
     }
 
@@ -82,7 +84,7 @@ subprojects {
     tasks.register('compileAll') { task ->
         description = "Compiles all the Kotlin and Java classes, including all of the test classes."
         group = "verification"
-        task.dependsOn tasks.withType(AbstractCompile)
+        task.dependsOn tasks.withType(AbstractCompile), tasks.withType(KotlinCompile)
     }
 
     apply plugin: 'io.gitlab.arturbosch.detekt'

--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -15,7 +15,7 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
                         groupId group.toString()
                         from components.findByName('kotlin') ?: components.java
                     }
-                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+                    pluginManager.withPlugin('net.corda.plugins.cordapp-cpk2') {
                         artifact tasks.named('cpk', Jar)
                     }
                     if (project.hasProperty("sourceJar")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ cliHostVersion=5.0.0
 # PF4J
 pf4jVersion=3.7.0
 
-kotlinVersion=1.7.10
+kotlinVersion=1.8.10
 
 kafkaClientVersion=3.3.1_1
 


### PR DESCRIPTION
Kotlin 1.8+ has dropped support for Java 6 and Java 7, and so has merged `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8` into `kotlin-stdlib`.