### PR TITLE
CORE-9799: revert to cordaPipeline for now as cordaPipelineKubernetes Agent can not publish to S3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
-cordaPipelineKubernetesAgent(
+cordaPipeline(
     runIntegrationTests: false,
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',


### PR DESCRIPTION
For now reverting to `cordaPipeline.groovy` as release pipelines require publishing to s3. This is currently not possible for `cordaPipelineKubernetes.groovy`.

This blocks internal releases, reverting for now as id rather not have to manually change this for each release tag, follow on issue to be created around allowing EKS -> S3 publishing. 

Note: nightlys remaining using cordaPipelineKubernetes
