### PR TITLE
CORE-11213: use beta 2 version of shared lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@beta2') _ // not to be merged back to release/os/5.0
 
 cordaPipeline(
     runIntegrationTests: false,


### PR DESCRIPTION
Use beta 2 version of shared lib to protect us from breaking changes in 5.0.1