### PR TITLE
CORE-10407: set J17 base image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,5 +8,6 @@ cordaPipeline(
     nexusAppId: 'net.corda-cli-host-0.0.1',
     publishToMavenS3Repository: true,
     javaVersion: '17',
-    enableNotifications: false
+    enableNotifications: false,
+    workerBaseImageTag: '17.0.4.1',
 )


### PR DESCRIPTION
setting Java17 base image on corda-cli

Missed in intal branch set up for these j17 branches 