### PR TITLE
CORE-10407: set CLI to use J17 base image for Java 17 work

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,5 +8,6 @@ cordaPipeline(
     nexusAppId: 'net.corda-cli-host-0.0.1',
     publishToMavenS3Repository: true,
     javaVersion: '17',
-    enableNotifications: false
+    enableNotifications: false,
+    workerBaseImageTag: '17.0.4.1'
 )


### PR DESCRIPTION
Override base image to ensure J17 version on this branch.

Otherwise, we end up with e2e failures as we try and execute J17 compiled code against the J11 base image here 

