### PR TITLE
ES-160: Fix dependecy resolution issue with .module files

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -31,6 +31,11 @@ repositories {
                 username = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
                 password = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
             }
+            metadataSources {
+                mavenPom()
+                artifact()
+                ignoreGradleMetadataRedirection()
+            }
         }
     } else {
         maven {


### PR DESCRIPTION
Remove the need for us to resolve gradle .module files.

Currently, an external repository infrastructure issue is blocking builds as a result, these can not be resolved, this change tell s Gradle to explicitly ignore these for the BuildSrc dir as currently a Jib module fails with the following

   > Could not parse module metadata https://software.r3.com/artifactory/corda-remotes/com/google/cloud/tools/jib-core/0.22.0/jib-core-0.22.0.module