### PR TITLE
ES-313: use latest Java 11 Azul Zulu base image plus various version bumps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,11 @@ dependencies {
     implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
     implementation "com.github.kittinunf.fuel:fuel:${fuelVersion}"
     implementation "com.github.kittinunf.fuel:fuel-json:${fuelVersion}"
+    constraints {
+        implementation("org.json:json:${jsonVersion}") {
+            because("Required until fuel-json updates it's internal version of org.json, not fixed as of fuel version 2.3.1")
+        }
+    }
 
     api "info.picocli:picocli:${picoCliVersion}"
 

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -109,7 +109,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('11')
+            getObjects().property(String).convention('11.0.16.1-11.58.23')
 
     @Input
     final Property<String> subDir =

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -109,7 +109,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('11.0.15-11.56.19')
+            getObjects().property(String).convention('11')
 
     @Input
     final Property<String> subDir =

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,12 +21,13 @@ commonsLangVersion=3.12.0
 snakeyamlVersion=2.0
 fuelVersion=2.3.1
 jacksonVersion=2.15.0
+jsonVersion=20230227
 
 junitJupiterVersion=5.9.3
 
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+
-jibCoreVersion=0.22.0
+jibCoreVersion=0.23.0
 dependencyCheckVersion=0.46.+
 
 # Artifactory


### PR DESCRIPTION
Update our base image of Azul Zulu to take the latest Java11, which itself uses a later base image of Ubuntu (jammy-20230308).

Also updated the following
- Jib core 0.22 -> 0.23
- org.json:json - transitive via `com.github.kittinunf.fuel:fuel-json`

Companion corda-runtime-os commit: https://github.com/corda/corda-runtime-os/pull/3779
