### PR TITLE
CORE-12501 Support Log4J JsonTemplateLayout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    }
+}
+
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'application'
@@ -12,6 +18,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    implementation "org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion"
 
     // removes jacksons large libs from plugins
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
@@ -59,8 +66,29 @@ tasks.named("run") {
     }
 }
 
+def mergeLog4j2Plugins = tasks.register('mergeLog4j2Plugins') {
+    dependsOn configurations.runtimeClasspath
+    inputs.files(configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) })
+    def outputDir = layout.buildDirectory.dir('log4j')
+    outputs.dir(outputDir)
+
+    doLast {
+        def inputFiles = inputs.files.getFiles().findAll { it.name == 'Log4j2Plugins.dat' }.collect { it.toURI().toURL() }
+        if (inputFiles) {
+            def combinedCache = new org.apache.logging.log4j.core.config.plugins.processor.PluginCache()
+            combinedCache.loadCacheFiles(Collections.enumeration(inputFiles))
+            def outputFile = outputDir.get().file('META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat').asFile
+            outputFile.parentFile.mkdirs()
+            try (OutputStream out = new FileOutputStream(outputFile)) {
+                combinedCache.writeCache(out)
+            }
+        }
+    }
+}
+
 def cordaCLi = tasks.named('jar', Jar) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    dependsOn mergeLog4j2Plugins
 
     from (sourceSets.main.output)
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
@@ -70,8 +98,10 @@ def cordaCLi = tasks.named('jar', Jar) {
         exclude "META-INF/*.EC"
         exclude "META-INF/INDEX.LIST"
         exclude "META-INF/versions/*/module-info.class"
+        exclude "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat"
         exclude "module-info.class"
     }
+    from(mergeLog4j2Plugins)
 
     manifest {
         attributes["Main-Class"] = appMainClass


### PR DESCRIPTION
https://github.com/corda/corda-runtime-os/pull/3766 switched to using `JsonTemplateLayout` as the default in the Corda Helm chart. This PR adds the necessary classes to the CLI JAR/image (with the same additional complexity to handle the merging of the plugin caches in the fat JAR).