### PR TITLE
CORE-13380: Label Image With Source Information

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -322,10 +322,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         // regular git commands when the task is being executed from within CI.
         def gitBranch = ""
         if (System.getenv().containsKey(JENKINS_JOB_URL_KEY)) {
-            if (System.getenv().containsKey(JENKINS_GIT_BRANCH_KEY)) {
-                gitBranch = System.getenv(JENKINS_GIT_BRANCH_KEY)  // branch builds on jenkins
-            } else if (System.getenv().containsKey(JENKINS_CHANGE_BRANCH_KEY)) {
+            if (System.getenv().containsKey(JENKINS_CHANGE_BRANCH_KEY)) {
                 gitBranch = System.getenv(JENKINS_CHANGE_BRANCH_KEY) // PR build on jenkins
+            } else if (System.getenv().containsKey(JENKINS_GIT_BRANCH_KEY)) {
+                gitBranch = System.getenv(JENKINS_GIT_BRANCH_KEY)  // branch builds on jenkins
             }
         } else {
             gitBranch = gitBranchTask.flatMap { it.branch }.get()

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -29,8 +29,11 @@ abstract class DeployableContainerBuilder extends DefaultTask {
     private final String version = project.version
     private final String cliHostVersion = project.cliHostVersion
     private String targetRepo
-    private def gitTask
     private def gitLogTask
+    private def gitBranchTask
+    private def gitRemoteTask
+    private def gitRevisionTask
+    private def gitShortRevisionTask
     private def releaseType
 
     @Inject
@@ -150,8 +153,21 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         description = 'Creates a new "corda-dev" image with the file specified in "overrideFilePath".'
         group = 'publishing'
 
-        gitTask = project.tasks.register("gitVersion", GetLatestGitRevision.class)
-        super.dependsOn(gitTask)
+        gitBranchTask = project.tasks.register("gitBranch", GetGitBranch.class)
+        super.dependsOn(gitBranchTask)
+
+        gitRemoteTask = project.tasks.register("gitRemote", GetGitRemoteUrl.class)
+        super.dependsOn(gitRemoteTask)
+
+        gitRevisionTask = project.tasks.register("gitRevision", GetGitRevision.class)
+        super.dependsOn(gitRevisionTask)
+
+        // TODO: remove once CORE-13474 has been implemented.
+        // Several pipelines currently use 'git rev-parse --short' to determine the custom image tag to use when
+        // deploying corda and the length of the abbreviated commit hash is determined by local Git configuration, so
+        // we can't assume that the default of 7 is used everywhere.
+        gitShortRevisionTask = project.tasks.register("gitShortRevision", GetGitShortRevision.class)
+        super.dependsOn(gitShortRevisionTask)
 
         gitLogTask = project.tasks.register("gitMessageTask", getLatestGitCommitMessage.class)
         super.dependsOn(gitLogTask)
@@ -169,9 +185,13 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         def containerizationDir = Paths.get("$buildBaseDir/containerization/")
 
         String tagPrefix = ""
-        String gitRevision = gitTask.flatMap { it.revision }.get()
+        String gitRemote = gitRemoteTask.flatMap { it.url }.get()
+        String gitBranch = gitBranchTask.flatMap { it.branch }.get()
+        String gitRevision = gitRevisionTask.flatMap { it.revision }.get()
+        String gitRevisionShortHash = gitShortRevisionTask.flatMap { it.revision }.get()
         def jiraTicket = hasJiraTicket()
         def timeStamp =  new SimpleDateFormat("ddMMyy").format(new Date())
+        logger.quiet("GitRemote: '{}', GitBranch: '{}', GitCommit: '{}'", gitRemote, gitBranch, gitRevision)
 
         if (!(new File(containerizationDir.toString())).exists()) {
             logger.info("Created containerization dir")
@@ -205,6 +225,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             logger.info("Resolving base image ${baseImageName.get()}: ${baseImageTag.get()} from remote repo")
             builder = setCredentialsOnBaseImage(builder)
         }
+
+        builder.addLabel("com.r3.corda.git.branch", gitBranch)
+        builder.addLabel("org.opencontainers.image.source", gitRemote)
+        builder.addLabel("org.opencontainers.image.revision", gitRevision)
 
         // If there is no tag for the image - we can't use RegistryImage.named
         builder.setCreationTime(Instant.now())
@@ -260,7 +284,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         } else if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "preTest-${tagPrefix}"+version)
-            tagContainer(builder, "preTest-${tagPrefix}"+gitRevision)
+            tagContainer(builder, "preTest-${tagPrefix}"+gitRevisionShortHash)
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}latest-${cliHostVersion}")
@@ -268,10 +292,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}unstable-${cliHostVersion}")
-            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevisionShortHash}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"
-            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevisionShortHash}")
         } else if (releaseType == 'BETA' && nightlyBuild.get()){
             targetRepo = "corda-os-docker-nightly.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}nightly")
@@ -281,15 +305,15 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             if (!jiraTicket.isEmpty()) {
                 tagContainer(builder, "${tagPrefix}nightly-" + jiraTicket)
                 tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + timeStamp)
-                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + gitRevision)
+                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + gitRevisionShortHash)
             }else{
                 gitAndVersionTag(builder, "${tagPrefix}nightly-" + version)
-                gitAndVersionTag(builder, "${tagPrefix}nightly-" + gitRevision)
+                gitAndVersionTag(builder, "${tagPrefix}nightly-" + gitRevisionShortHash)
             }
         } else{
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "latest-local-${cliHostVersion}")
-            gitAndVersionTag(builder, gitRevision)
+            gitAndVersionTag(builder, gitRevisionShortHash)
         }
     }
 
@@ -347,19 +371,73 @@ abstract class DeployableContainerBuilder extends DefaultTask {
     }
 
     /**
-     * Helper task to retrieve get the latest git hash
+     * Helper task to retrieve the latest full git hash
      */
-    static class GetLatestGitRevision extends Exec {
+    static class GetGitRevision extends Exec {
         @Internal
         final Property<String> revision
 
         @Inject
-        GetLatestGitRevision(ObjectFactory objects, ProviderFactory providers) {
+        GetGitRevision(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'rev-parse', '--verify', 'HEAD'
+            standardOutput = new ByteArrayOutputStream()
+            revision = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve the latest full git hash
+     */
+    static class GetGitShortRevision extends Exec {
+        @Internal
+        final Property<String> revision
+
+        @Inject
+        GetGitShortRevision(ObjectFactory objects, ProviderFactory providers) {
             executable 'git'
             args 'rev-parse', '--verify', '--short', 'HEAD'
             standardOutput = new ByteArrayOutputStream()
             revision = objects.property(String).value(
-                    providers.provider { standardOutput.toString() }
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve the git branch
+     */
+    static class GetGitBranch extends Exec {
+        @Internal
+        final Property<String> branch
+
+        @Inject
+        GetGitBranch(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'rev-parse', '--abbrev-ref', 'HEAD'
+            standardOutput = new ByteArrayOutputStream()
+            branch = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve get the git remote repository
+     */
+    static class GetGitRemoteUrl extends Exec {
+        @Internal
+        final Property<String> url
+
+        @Inject
+        GetGitRemoteUrl(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'remote', 'get-url', 'origin'
+            standardOutput = new ByteArrayOutputStream()
+            url = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
             )
         }
     }

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -416,7 +416,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         @Inject
         GetGitBranch(ObjectFactory objects, ProviderFactory providers) {
             executable 'git'
-            args 'rev-parse', '--abbrev-ref', 'HEAD'
+            args 'branch', '--show-current'
             standardOutput = new ByteArrayOutputStream()
             branch = objects.property(String).value(
                     providers.provider { standardOutput.toString().trim() }


### PR DESCRIPTION
Add the following labels to the built images:
  - "com.r3.corda.git.branch": branch used.
  - "org.opencontainers.image.source": remote git url.
  - "org.opencontainers.image.revision": git commit hash.