### PR TITLE
CORE-13382: scan only runntime classpath 

### DIFF
--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -2,5 +2,6 @@
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',
-  snykTokenId: 'r3-snyk-corda5'
+  snykTokenId: 'r3-snyk-corda5',
+  snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$'"
 )

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,5 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaSnykScanPipeline (
-    snykTokenId: 'r3-snyk-corda5'
+    snykTokenId: 'r3-snyk-corda5',
+    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d"
 )


### PR DESCRIPTION
Updated snyk configuration to scan only shippable code in line with other repos.  Not items which are internal to the build system plugins etc

 