### PR TITLE
ES-89: removed obsolete parameter of shared pipeline

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,7 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaPipelineKubernetesAgent(
-    nexusAppId: 'net.corda-api-5.0',
     runIntegrationTests: false,
     dailyBuildCron: 'H 02 * * *',
     publishOSGiImage: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,5 @@ cordaPipeline(
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',
     publishRepoPrefix: 'engineering-tools-maven',
-    nexusAppId: 'net.corda-cli-host-0.0.1',
     publishToMavenS3Repository: true
 )


### PR DESCRIPTION
* removed obsolete `nexusAppId` parameter
* we no longer run checks with Nexus and the functionality is gone from shared pipelines
* on top of this `cordaPipelineKubernetesAgent` actively checks for non-existing parameters and it throws an exception when it finds one

This is just a cosmetic change and it does not modify any behaviour.