### PR TITLE
ES-89: Merging forward updates from release/5.0 to release/5.1

### DIFF
--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -2,5 +2,6 @@
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',
-  snykTokenId: 'r3-snyk-corda5'
+  snykTokenId: 'r3-snyk-corda5',
+  snykAdditionalCommands: "--configuration-matching='^runtimeClasspath\$'"
 )

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,7 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaPipelineKubernetesAgent(
-    nexusAppId: 'net.corda-api-5.0',
     runIntegrationTests: false,
     dailyBuildCron: 'H 02 * * *',
     publishOSGiImage: true,

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,5 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaSnykScanPipeline (
-    snykTokenId: 'r3-snyk-corda5'
+    snykTokenId: 'r3-snyk-corda5',
+    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d"
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,5 @@ cordaPipeline(
     publishOSGiImage: true,
     dailyBuildCron: 'H 03 * * *',
     publishRepoPrefix: 'engineering-tools-maven',
-    nexusAppId: 'net.corda-cli-host-0.0.1',
     publishToMavenS3Repository: true
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,3 +43,7 @@ gradleEnterpriseUrl = https://gradle.dev.r3.com
 
 #snyk version
 snykVersion = 0.4
+
+# License
+licenseName = The Apache License, Version 2.0
+licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
Includes:

* ES-371: Add Apache license (https://github.com/corda/corda-cli-plugin-host/pull/165)
* CORE-13382: Only Scan runtime classpath for shipped code (https://github.com/corda/corda-cli-plugin-host/pull/167)
* ES-89: removed obsolete parameter of shared pipeline (https://github.com/corda/corda-cli-plugin-host/pull/169)