### PR TITLE
CORE-13380: Label Image With Source Information (#163)

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -23,13 +23,18 @@ import java.time.Instant
  * A user may pass further custom arguments using the 'arguments' property when using this task type.
  */
 abstract class DeployableContainerBuilder extends DefaultTask {
-
     private static final String CONTAINER_LOCATION = "/opt/override/"
+    private static final String JENKINS_JOB_URL_KEY = "JENKINS_URL"
+    private static final String JENKINS_GIT_BRANCH_KEY = "GIT_BRANCH"
+    private static final String JENKINS_CHANGE_BRANCH_KEY = "CHANGE_BRANCH"
     private final String projectName = project.name
     private final String version = project.version
     private String targetRepo
-    private def gitTask
     private def gitLogTask
+    private def gitBranchTask
+    private def gitRemoteTask
+    private def gitRevisionTask
+    private def gitShortRevisionTask
     private def releaseType
 
     @Inject
@@ -149,8 +154,21 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         description = 'Creates a new "corda-dev" image with the file specified in "overrideFilePath".'
         group = 'publishing'
 
-        gitTask = project.tasks.register("gitVersion", GetLatestGitRevision.class)
-        super.dependsOn(gitTask)
+        gitBranchTask = project.tasks.register("gitBranch", GetGitBranch.class)
+        super.dependsOn(gitBranchTask)
+
+        gitRemoteTask = project.tasks.register("gitRemote", GetGitRemoteUrl.class)
+        super.dependsOn(gitRemoteTask)
+
+        gitRevisionTask = project.tasks.register("gitRevision", GetGitRevision.class)
+        super.dependsOn(gitRevisionTask)
+
+        // TODO: remove once CORE-13474 has been implemented.
+        // Several pipelines currently use 'git rev-parse --short' to determine the custom image tag to use when
+        // deploying corda and the length of the abbreviated commit hash is determined by local Git configuration, so
+        // we can't assume that the default of 7 is used everywhere.
+        gitShortRevisionTask = project.tasks.register("gitShortRevision", GetGitShortRevision.class)
+        super.dependsOn(gitShortRevisionTask)
 
         gitLogTask = project.tasks.register("gitMessageTask", getLatestGitCommitMessage.class)
         super.dependsOn(gitLogTask)
@@ -168,7 +186,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         def containerizationDir = Paths.get("$buildBaseDir/containerization/")
 
         String tagPrefix = ""
-        String gitRevision = gitTask.flatMap { it.revision }.get()
+        String gitRevisionShortHash = gitShortRevisionTask.flatMap { it.revision }.get()
         def jiraTicket = hasJiraTicket()
         def timeStamp =  new SimpleDateFormat("ddMMyy").format(new Date())
 
@@ -205,6 +223,9 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             builder = setCredentialsOnBaseImage(builder)
         }
 
+        // Add labels (branch, source code url and git commit SHA) to the image
+        addImageSourceLabels(builder)
+
         // If there is no tag for the image - we can't use RegistryImage.named
         builder.setCreationTime(Instant.now())
                .addLayer(
@@ -237,7 +258,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             logger.quiet("Forcing Jib to use ${targetPlatform.get()} platform")
             String[] osArch = targetPlatform.get().split("/")
             builder.setPlatforms(Set.of(new Platform(osArch[1], osArch[0])))
-        } else if (System.getenv().containsKey("JENKINS_URL") && multiArch.get()) {
+        } else if (System.getenv().containsKey(JENKINS_JOB_URL_KEY) && multiArch.get()) {
             logger.quiet("Running on CI server - producing arm64 and amd64 images, property multiArch is ${multiArch.get()}")
             builder.addPlatform("arm64","linux")
         } else if (System.properties['os.arch'] == "aarch64") { 
@@ -259,7 +280,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         } else if (preTest.get()) {
             targetRepo = "corda-os-docker-pre-test.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "preTest-${tagPrefix}"+version)
-            tagContainer(builder, "preTest-${tagPrefix}"+gitRevision)
+            tagContainer(builder, "preTest-${tagPrefix}"+gitRevisionShortHash)
         } else if (releaseType == 'RC' || releaseType == 'GA') {
             targetRepo = "corda-os-docker-stable.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}latest")
@@ -267,10 +288,10 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         } else if (releaseType == 'BETA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-unstable.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}unstable")
-            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevisionShortHash}")
         } else if (releaseType == 'ALPHA' && !nightlyBuild.get()) {
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"
-            gitAndVersionTag(builder, "${tagPrefix}${gitRevision}")
+            gitAndVersionTag(builder, "${tagPrefix}${gitRevisionShortHash}")
         } else if (releaseType == 'BETA' && nightlyBuild.get()){
             targetRepo = "corda-os-docker-nightly.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "${tagPrefix}nightly")
@@ -280,16 +301,39 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             if (!jiraTicket.isEmpty()) {
                 tagContainer(builder, "${tagPrefix}nightly-" + jiraTicket)
                 tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + timeStamp)
-                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + gitRevision)
+                tagContainer(builder, "${tagPrefix}nightly" + "-" + jiraTicket + "-" + gitRevisionShortHash)
             }else{
                 gitAndVersionTag(builder, "${tagPrefix}nightly-" + version)
-                gitAndVersionTag(builder, "${tagPrefix}nightly-" + gitRevision)
+                gitAndVersionTag(builder, "${tagPrefix}nightly-" + gitRevisionShortHash)
             }
         } else{
             targetRepo = "corda-os-docker-dev.software.r3.com/corda-os-${containerName}"
             tagContainer(builder, "latest-local")
-            gitAndVersionTag(builder, gitRevision)
+            gitAndVersionTag(builder, gitRevisionShortHash)
         }
+    }
+
+    private void addImageSourceLabels(JibContainerBuilder builder) {
+        String gitRemote = gitRemoteTask.flatMap { it.url }.get()
+        String gitRevision = gitRevisionTask.flatMap { it.revision }.get()
+
+        // Jenkins automatically overrides the branch name when checking out the source code, we can't just use
+        // regular git commands when the task is being executed from within CI.
+        def gitBranch = ""
+        if (System.getenv().containsKey(JENKINS_JOB_URL_KEY)) {
+            if (System.getenv().containsKey(JENKINS_CHANGE_BRANCH_KEY)) {
+                gitBranch = System.getenv(JENKINS_CHANGE_BRANCH_KEY) // PR build on jenkins
+            } else if (System.getenv().containsKey(JENKINS_GIT_BRANCH_KEY)) {
+                gitBranch = System.getenv(JENKINS_GIT_BRANCH_KEY)  // branch builds on jenkins
+            }
+        } else {
+            gitBranch = gitBranchTask.flatMap { it.branch }.get()
+        }
+
+        logger.quiet("GitRemote: '{}', GitBranch: '{}', GitCommit: '{}'", gitRemote, gitBranch, gitRevision)
+        builder.addLabel("com.r3.corda.git.branch", gitBranch)
+        builder.addLabel("org.opencontainers.image.source", gitRemote)
+        builder.addLabel("org.opencontainers.image.revision", gitRevision)
     }
 
     private void gitAndVersionTag(JibContainerBuilder builder, String gitRevision) {
@@ -346,19 +390,73 @@ abstract class DeployableContainerBuilder extends DefaultTask {
     }
 
     /**
-     * Helper task to retrieve get the latest git hash
+     * Helper task to retrieve the latest full git hash
      */
-    static class GetLatestGitRevision extends Exec {
+    static class GetGitRevision extends Exec {
         @Internal
         final Property<String> revision
 
         @Inject
-        GetLatestGitRevision(ObjectFactory objects, ProviderFactory providers) {
+        GetGitRevision(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'rev-parse', '--verify', 'HEAD'
+            standardOutput = new ByteArrayOutputStream()
+            revision = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve the latest full git hash
+     */
+    static class GetGitShortRevision extends Exec {
+        @Internal
+        final Property<String> revision
+
+        @Inject
+        GetGitShortRevision(ObjectFactory objects, ProviderFactory providers) {
             executable 'git'
             args 'rev-parse', '--verify', '--short', 'HEAD'
             standardOutput = new ByteArrayOutputStream()
             revision = objects.property(String).value(
-                    providers.provider { standardOutput.toString() }
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve the git branch
+     */
+    static class GetGitBranch extends Exec {
+        @Internal
+        final Property<String> branch
+
+        @Inject
+        GetGitBranch(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'branch', '--show-current'
+            standardOutput = new ByteArrayOutputStream()
+            branch = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
+            )
+        }
+    }
+
+    /**
+     * Helper task to retrieve get the git remote repository
+     */
+    static class GetGitRemoteUrl extends Exec {
+        @Internal
+        final Property<String> url
+
+        @Inject
+        GetGitRemoteUrl(ObjectFactory objects, ProviderFactory providers) {
+            executable 'git'
+            args 'remote', 'get-url', 'origin'
+            standardOutput = new ByteArrayOutputStream()
+            url = objects.property(String).value(
+                    providers.provider { standardOutput.toString().trim() }
             )
         }
     }


### PR DESCRIPTION
Add the following labels to the built images:
  - "com.r3.corda.git.branch": branch used.
  - "org.opencontainers.image.source": remote git url.
  - "org.opencontainers.image.revision": git commit hash.

* Use git branch --show-current to get the current branch
* Use Jenkins environment variables when building images from within CI
* Check 'CHANGE_BRANCH' before 'GIT_BRANCH'

(cherry picked from commit 6f4868fc794a6d0fe8b9d4d19af13e1622b8bfb4)