### PR TITLE
ES-852: Clean up of Artifact repository definitions 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,7 @@ dependencyCheckVersion=0.46.+
 
 # Artifactory
 artifactoryContextUrl = https://software.r3.com/artifactory
+publicArtifactURL = https://download.corda.net/maven
 systemRulesVersion=1.19.0
 artifactoryPluginVersion = 4.28.2
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,7 +36,6 @@ pluginManagement {
                     password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
                 }
             }
-            gradlePluginPortal()
             maven {
                 url "${artifactoryContextUrl}/engineering-tools-maven"
                 authentication {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,13 +18,13 @@ pluginManagement {
             }
         } else {
             maven {
-                url "https://download.corda.net/maven/corda-dependencies"
+                url "${publicArtifactURL}/corda-releases"
                 content {
                     includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
                 }
             }
             maven {
-                url "${publicArtifactURL}/corda-os-maven"
+                url "${artifactoryContextUrl}/corda-os-maven"
                 content {
                     includeGroupByRegex 'net\\.corda\\.cordapp(\\..*)?'
                 }
@@ -70,7 +70,6 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-
         def cordaUseCache = System.getenv("CORDA_USE_CACHE")
         if (cordaUseCache != null) {
             maven {
@@ -85,27 +84,8 @@ dependencyResolutionManagement {
                 }
             }
         } else {
-            mavenCentral()
-
             maven {
                 url = "${publicArtifactURL}/corda-dependencies"
-            }
-            maven {
-                url = "$artifactoryContextUrl/${System.getenv('CORDA_CONSUME_REPOSITORY_KEY') ?: 'corda-os-maven'}"
-                credentials {
-                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-                }
-            }
-            maven {
-                url "${artifactoryContextUrl}/corda-enterprise"
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-                }
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,13 +18,13 @@ pluginManagement {
             }
         } else {
             maven {
-                url "${artifactoryContextUrl}/corda-releases"
+                url "https://download.corda.net/maven/corda-dependencies"
                 content {
                     includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
                 }
             }
             maven {
-                url "${artifactoryContextUrl}/corda-os-maven"
+                url "${publicArtifactURL}/corda-os-maven"
                 content {
                     includeGroupByRegex 'net\\.corda\\.cordapp(\\..*)?'
                 }
@@ -88,7 +88,7 @@ dependencyResolutionManagement {
             mavenCentral()
 
             maven {
-                url = "$artifactoryContextUrl/corda-dependencies"
+                url = "${publicArtifactURL}/corda-dependencies"
             }
             maven {
                 url = "$artifactoryContextUrl/${System.getenv('CORDA_CONSUME_REPOSITORY_KEY') ?: 'corda-os-maven'}"


### PR DESCRIPTION
- A number of artifactory repos are migrating to be private, to ensure the open source community can continue to build Corda. These have been mirrored at `https://download.corda.net/maven`

This PR also cleans up repo definitions which had several redundant entries and duplications-

- `corda-enterprise` artifact repo declaration not needed
- corda-os-maven` artifact repo declaration not needed
- remove duplicate entry for gradle plugin portal 