### PR TITLE
ES-616: Add Gradle Version Catalog implementation for corda-cli-plugin-host

### DIFF
--- a/PluginGuidelines.md
+++ b/PluginGuidelines.md
@@ -45,13 +45,13 @@ In the `dependencies` block, at a minimum, import the following:
 
 ```groovy
 dependencies {
-    compileOnly "org.pf4j:pf4j:$pf4jVersion"
+    compileOnly libs.pf4j
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
-    kapt "org.pf4j:pf4j:$pf4jVersion"
-    kapt "info.picocli:picocli:$picocliVersion"
+    kapt libs.pf4j
+    kapt libs.picocli
 
-    testImplementation "org.pf4j:pf4j:$pf4jVersion"
+    testImplementation libs.pf4j
     testCompileOnly "net.corda.cli.host:api:$pluginHostVersion"
 }
 ```

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,6 +8,6 @@ group = "net.corda.cli.host"
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compileOnly "org.pf4j:pf4j:${pf4jVersion}"
-    api "info.picocli:picocli:$picoCliVersion"
+    compileOnly libs.pf4j
+    api libs.picocli
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api libs.picocli
 
     testImplementation libs.junit.jupiter
-    testImplementation "com.github.stefanbirkner:system-lambda:1.2.1"
+    testImplementation libs.system.lambda
 }
 
 version rootProject.version

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath "org.apache.logging.log4j:log4j-core:$log4jVersion"
+        classpath libs.log4j.core
     }
 }
 
@@ -15,34 +15,30 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
-    implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion"
+    implementation libs.bundles.log4j
 
     // removes jacksons large libs from plugins
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    implementation libs.jackson.module
+    implementation libs.jackson.dataformat
+    implementation libs.jackson.core
 
     // removes the kafka clients large size from any plugins requiring it (topic config etc)
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation libs.kafka.clients
 
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "org.pf4j:pf4j:${pf4jVersion}"
-    implementation "org.apache.commons:commons-lang3:${commonsLangVersion}"
-    implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
-    implementation "com.github.kittinunf.fuel:fuel:${fuelVersion}"
-    implementation "com.github.kittinunf.fuel:fuel-json:${fuelVersion}"
+    implementation libs.slf4j.api
+    implementation libs.pf4j
+    implementation libs.commons.lang3
+    implementation libs.snakeyaml
+    implementation libs.bundles.fuel
     constraints {
-        implementation("org.json:json:${jsonVersion}") {
+        implementation(libs.json) {
             because("Required until fuel-json updates it's internal version of org.json, not fixed as of fuel version 2.3.1")
         }
     }
 
-    api "info.picocli:picocli:${picoCliVersion}"
+    api libs.picocli
 
-    testImplementation "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
+    testImplementation libs.junit.jupiter
     testImplementation "com.github.stefanbirkner:system-lambda:1.2.1"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ subprojects {
         dependencies {
             detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
             constraints {
-                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                detekt(libs.snakeyaml) {
                     because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
                 }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,27 +3,7 @@ kotlin.stdlib.default.dependency=false
 # The version of cli-host we will publish
 cliHostVersion=5.0.0
 
-# PF4J
-pf4jVersion=3.9.0
-
 kotlinVersion=1.8.21
-
-kafkaClientVersion=3.4.0_1
-
-# Logging
-log4jVersion=2.20.0
-slf4jVersion=1.7.36
-
-# pico CLI
-picoCliVersion=4.7.3
-
-commonsLangVersion=3.12.0
-snakeyamlVersion=2.0
-fuelVersion=2.3.1
-jacksonVersion=2.15.0
-jsonVersion=20230227
-
-junitJupiterVersion=5.9.3
 
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+
@@ -33,7 +13,6 @@ dependencyCheckVersion=0.46.+
 # Artifactory
 artifactoryContextUrl = https://software.r3.com/artifactory
 publicArtifactURL = https://download.corda.net/maven
-systemRulesVersion=1.19.0
 artifactoryPluginVersion = 4.28.2
 
 # Gradle enterprise Details
@@ -48,3 +27,7 @@ snykVersion = 0.4
 # License
 licenseName = The Apache License, Version 2.0
 licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
+
+# Gradle Version Catalog
+cordaVersionCatalog=1.0.0-beta-+
+releaseVersionCatalog=release-5.0

--- a/plugins/example/build.gradle
+++ b/plugins/example/build.gradle
@@ -5,12 +5,12 @@ plugins {
 dependencies {
     compileOnly project(":api")
 
-    implementation "org.pf4j:pf4j:${pf4jVersion}"
-    kapt "org.pf4j:pf4j:${pf4jVersion}"
+    implementation libs.pf4j
+    kapt libs.pf4j
 
     testImplementation project(":api")
-    testImplementation "org.pf4j:pf4j:${pf4jVersion}"
-    testImplementation "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
+    testImplementation libs.pf4j
+    testImplementation libs.junit.jupiter
     testImplementation "com.github.stefanbirkner:system-lambda:1.2.1"
 }
 

--- a/plugins/example/build.gradle
+++ b/plugins/example/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation project(":api")
     testImplementation libs.pf4j
     testImplementation libs.junit.jupiter
-    testImplementation "com.github.stefanbirkner:system-lambda:1.2.1"
+    testImplementation libs.system.lambda
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -86,7 +86,21 @@ dependencyResolutionManagement {
             maven {
                 url = "${publicArtifactURL}/corda-dependencies"
             }
+            maven {
+                url = "$artifactoryContextUrl/corda-os-maven"
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+            }
         }
+    }
+    versionCatalogs {
+        libs {
+            from("net.corda:$releaseVersionCatalog:$cordaVersionCatalog")        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -100,7 +100,8 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         libs {
-            from("net.corda:$releaseVersionCatalog:$cordaVersionCatalog")        }
+            from("net.corda:$releaseVersionCatalog:$cordaVersionCatalog")
+        }
     }
 }
 


### PR DESCRIPTION
**Description:**
As part improving version dependencies within Corda we have added [Gradle Version Catalog](https://docs.gradle.org/current/userguide/platforms.html) for corda-cli-plugin-host. This will allow us to use the newly created central repository [corda-version-catalog](https://github.com/corda/corda-version-catalog) for maintaining and managing 3rd parties dependency that is use within corda-cli-plugin-host.

**Changes:**
Added implementation of using Gradle Version Catalog for corda-cli-plugin-host repo in build.gradle file
Replace all version reference occurrences which use gradle.properties to version catalog in build.gradle files.

pf4jVersion=3.9.0
kafkaClientVersion=3.4.0_1
log4jVersion=2.20.0
slf4jVersion=1.7.36
picoCliVersion=4.7.3
commonsLangVersion=3.12.0
snakeyamlVersion=2.0
fuelVersion=2.3.1
jacksonVersion=2.15.0
jsonVersion=20230227
junitJupiterVersion=5.9.3

**Testing**
Tested with release-5.0 for Artifactory cordaVersionCatalog=1.0.0-beta-+ created in [corda-version-catalog](https://github.com/corda/corda-version-catalog) repo.

**Documentation**
Rendered version: https://github.com/corda/platform-eng-design/blob/knguyen/ES-374/gradle_version_catalog/core/corda-5/corda-5.0/infrastructure/build/build-dependencies/corda5-version-catalog.md