### PR TITLE
ES-1031: Restore CODEOWNERS file for 5.0 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
-# Reduced list for the duration of 5.0 code freeze - not to be merged forward  
-* @mnesbit @driessamyn @ronanbrowne
+* @corda/rest
+# Build scripts should be audited by BLT
+*.gradle           @corda/blt
+gradle.properties  @corda/corda5-team-leads
+Jenkinsfile        @corda/blt
+.ci/*              @corda/blt
+gradle/*           @corda/blt


### PR DESCRIPTION
Restoring `CODEOWNERS` file to its original format, as part of this the GitHub freeze branch feature will be active on 5.0 streams.

Meaning PR's will still go through the normal review process and need to be approved by relevant groups in the CODEOWNERS file but, Merging will be blocked on that branch at a configuration level, until a repo admin temporarily lifts the freeze

