### PR TITLE
ES-1061: Update JenkinsfileWindowsCompatibility to use correct version of shared lib

### DIFF
--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 windowsCompatibility(
     runIntegrationTests: false,


### PR DESCRIPTION
Correct Shared library version for the windows nightly, point to the 5.1 branch in line with 5.1 of this repo

No functional change 