### PR TITLE
CORE-16786: Revert pf4j to 3.9 (#192)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.stdlib.default.dependency=false
 cliHostVersion=5.1.0
 
 # PF4J
-pf4jVersion=3.10.0
+pf4jVersion=3.9.0
 
 kotlinVersion=1.8.21
 


### PR DESCRIPTION
This reverts commit bdf7c8a2dfd25c0eaa93c98b3b152d3365b32453.

3.10 pulls in slf4j 2.0, need to consider the effect of this change.