### PR TITLE
CORE-16786: Upgrade CLI PF4J to 3.10 and SLF4J to 2.0.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion"
 
     // removes jacksons large libs from plugins

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ kotlin.stdlib.default.dependency=false
 cliHostVersion=5.1.0
 
 # PF4J
-pf4jVersion=3.9.0
+pf4jVersion=3.10.0
 
 kotlinVersion=1.8.21
 
 # Logging
 log4jVersion=2.20.0
-slf4jVersion=1.7.36
+slf4jVersion=2.0.6
 
 # pico CLI
 picoCliVersion=4.7.3


### PR DESCRIPTION
This change upgrades PF4J to 3.10, the change log can be viewed here:
https://github.com/pf4j/pf4j/blob/master/CHANGELOG.md#3100---2023-09-06

One of the changes included in PF4J is an upgrade to SLF4J 2. This change uses SLF4J 2 for the CLI.