### PR TITLE
ES-1608: remove redundant property in Jenkins file 

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -6,6 +6,5 @@ cordaPipelineKubernetesAgent(
     publishOSGiImage: true,
     gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',
     generateSbom: true,
-    javaVersion: '17',
-    workerBaseImageTag: '17.0.4.1-17.36.17'
+    javaVersion: '17'
     )


### PR DESCRIPTION
`workerBaseImageTag` is no longer a valid property this is dead code, this property is set directly at the project level rather than overridden in Jenkins file 