### PR TITLE
ES-1621: Update JenkinsfileMergeAutomation use correct branch for originBranch / targetBranch

### DIFF
--- a/.ci/JenkinsfileMergeAutomation
+++ b/.ci/JenkinsfileMergeAutomation
@@ -14,13 +14,13 @@
  * the branch name of origin branch, it should match the current branch
  * and it acts as a fail-safe inside {@code forwardMerger} pipeline
  */
-String originBranch = 'release/5.1'
+String originBranch = 'release/5.2'
 
 /**
  * the branch name of target branch, it should be the branch with the next version
  * after the one in current branch.
  */
-String targetBranch = 'release/5.2'
+String targetBranch = 'release/5.3'
 
 /**
  * Forward merge any changes between {@code originBranch} and {@code targetBranch}


### PR DESCRIPTION
the 5.2 branch should set it's originBranch as 5.2 and it's target as 5.3, this is just a placeholder file for now and will not do anything until 5.3 branch exists