### PR TITLE
ES-1621: active forward merge automation from 5.1 -> 5.2

### DIFF
--- a/.ci/JenkinsfileMergeAutomation
+++ b/.ci/JenkinsfileMergeAutomation
@@ -1,0 +1,32 @@
+#! groovy
+@Library('corda-shared-build-pipeline-steps@5.1') _
+
+/**
+ * Forward merge any changes in current branch to the branch with following version.
+ *
+ * Please note, the branches names are intentionally separated as variables, to minimised conflicts
+ * during automated merges for this file.
+ *
+ * These variables should be updated when a new version is cut
+ */
+
+/**
+ * the branch name of origin branch, it should match the current branch
+ * and it acts as a fail-safe inside {@code forwardMerger} pipeline
+ */
+String originBranch = 'release/5.1'
+
+/**
+ * the branch name of target branch, it should be the branch with the next version
+ * after the one in current branch.
+ */
+String targetBranch = 'release/5.2'
+
+/**
+ * Forward merge any changes between {@code originBranch} and {@code targetBranch}
+ */
+forwardMerger(
+    targetBranch: targetBranch,
+    originBranch: originBranch,
+    slackChannel: '#c5-forward-merge-bot-notifications'
+)


### PR DESCRIPTION
This PR will activate forward merge automation between 5.1 and 5.2, reducing the need for manual merges. Only one PR is raised per target branch. at a time, any outstanding changes will be swept up in the next merge once PR A is merged.

**PR Description generated by merge bot**
The description of the PR will be automatically filled out with all pull requests carried forward in the merge.

**PR Reviewers**
The original authors of the pull requests will also be tagged in the forward merge so they can sanity-check their work.

**Manual merges:**
On occasion, you may not wish for a change to be brought forward if this is the case, on the original PR you can add the label `manual-merge`. The automation checks for the presence of this label and will take no action if it is found, your change will need to be manually merged forward, if required. 

**Slack integration:**
`c5-forward-merge-bot-notifications` will auto-update by a bot user once a PR is ready to be merged 

