### PR TITLE
CORE-19112: Turn off colour output in CLI under test

### DIFF
--- a/plugins/example/src/test/kotlin/net/corda/cli/plugins/examples/ExamplePluginTest.kt
+++ b/plugins/example/src/test/kotlin/net/corda/cli/plugins/examples/ExamplePluginTest.kt
@@ -36,6 +36,8 @@ class ExamplePluginTest {
 
             return String(byteArrayOutputStream.toByteArray()).replace("\r\n", "\n")
         }
+
+        private val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
     }
 
     @Test
@@ -44,9 +46,9 @@ class ExamplePluginTest {
         val app = ExamplePlugin.ExamplePluginEntry()
 
         val outText = tapSystemErr {
-            CommandLine(
-                app
-            ).execute("")
+            CommandLine(app)
+                .setColorScheme(colorScheme)
+                .execute("")
         }
 
         assertTrue(


### PR DESCRIPTION
This prevents terminal escape codes from being caputred by the test.