### PR TITLE
CORE-0 Jackson version upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ picoCliVersion=4.7.3
 
 commonsLangVersion=3.12.0
 snakeyamlVersion=2.0
-jacksonVersion=2.15.0
+jacksonVersion=2.17.0
 
 junitJupiterVersion=5.10.0
 


### PR DESCRIPTION
 Necessary to be able to complete: https://github.com/corda/corda-runtime-os/pull/5869

NOTE: not moved to version catalog as this repo is due to be deprecated.